### PR TITLE
Add Discord bot implementation for LLM Council

### DIFF
--- a/DISCORD_SETUP.md
+++ b/DISCORD_SETUP.md
@@ -1,0 +1,362 @@
+# Discord Bot Setup Guide
+
+This guide will help you run the LLM Council as a Discord bot on your NAS or any Linux server.
+
+## Overview
+
+Instead of the web interface, this Discord bot allows you to interact with the LLM Council directly through Discord. The bot:
+- Responds to `!council <question>` commands
+- Can be mentioned directly: `@LLMCouncil <question>`
+- Creates a thread for each query to keep discussions organized
+- Shows all 3 stages using Discord embeds (nice formatting)
+- Stores conversation history in JSON files per Discord channel
+
+## Prerequisites
+
+- **Python 3.10+** installed on your NAS
+- **Discord account** with permissions to create a bot
+- **OpenRouter API key** with credits
+
+## Step 1: Create a Discord Bot
+
+### 1.1 Create Application on Discord Developer Portal
+
+1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
+2. Click **"New Application"**
+3. Give it a name (e.g., "LLM Council")
+4. Click **"Create"**
+
+### 1.2 Create Bot User
+
+1. In your application, go to the **"Bot"** tab
+2. Click **"Add Bot"** → Confirm
+3. Under **"Token"**, click **"Reset Token"** and copy it (save this for later!)
+4. Enable these **Privileged Gateway Intents**:
+   - ✅ Message Content Intent
+   - ✅ Server Members Intent (optional)
+
+### 1.3 Invite Bot to Your Server
+
+1. Go to **"OAuth2"** → **"URL Generator"**
+2. Select scopes:
+   - ✅ `bot`
+   - ✅ `applications.commands`
+3. Select bot permissions:
+   - ✅ Send Messages
+   - ✅ Send Messages in Threads
+   - ✅ Create Public Threads
+   - ✅ Embed Links
+   - ✅ Read Message History
+4. Copy the generated URL and open it in your browser
+5. Select your Discord server and authorize
+
+## Step 2: Install Dependencies
+
+On your NAS, navigate to the project directory:
+
+```bash
+cd /path/to/llm-council
+```
+
+### Option A: Using uv (recommended)
+
+```bash
+# Install discord.py
+uv add discord.py
+
+# Sync dependencies
+uv sync
+```
+
+### Option B: Using pip
+
+```bash
+pip install discord.py httpx python-dotenv
+```
+
+## Step 3: Configure Environment Variables
+
+Edit your `.env` file:
+
+```bash
+nano .env
+```
+
+Add both API keys:
+
+```bash
+# OpenRouter API key
+OPENROUTER_API_KEY=sk-or-v1-your-key-here
+
+# Discord bot token
+DISCORD_BOT_TOKEN=your-discord-bot-token-here
+```
+
+Save and exit (`Ctrl+X`, `Y`, `Enter`).
+
+## Step 4: Configure Models (Optional)
+
+Edit `backend/config.py` to customize your council:
+
+```python
+# Council members - reduce this list to save costs
+COUNCIL_MODELS = [
+    "openai/gpt-5.1",
+    "google/gemini-3-pro-preview",
+    "anthropic/claude-sonnet-4.5",
+]
+
+# Chairman model - Opus 4.1 for high-quality synthesis
+CHAIRMAN_MODEL = "anthropic/claude-opus-4.1"
+```
+
+**Cost-saving tip:** Fewer models = cheaper! You can run with just 2-3 council members.
+
+## Step 5: Run the Bot
+
+### Manual Run (for testing)
+
+```bash
+uv run python -m backend.discord_bot
+```
+
+You should see:
+```
+✅ Bot logged in as LLM Council (ID: 123456789)
+🎯 Ready to receive council queries!
+```
+
+Test it in Discord:
+```
+!council What is the capital of France?
+```
+
+### Run as Background Service (for production)
+
+#### Option A: Using tmux (simple)
+
+```bash
+# Start tmux session
+tmux new -s council-bot
+
+# Run the bot
+uv run python -m backend.discord_bot
+
+# Detach: Press Ctrl+B, then D
+# Reattach later: tmux attach -t council-bot
+```
+
+#### Option B: Using systemd (recommended for NAS)
+
+Create a systemd service file:
+
+```bash
+sudo nano /etc/systemd/system/llm-council-bot.service
+```
+
+Add this configuration (adjust paths for your system):
+
+```ini
+[Unit]
+Description=LLM Council Discord Bot
+After=network.target
+
+[Service]
+Type=simple
+User=your-username
+WorkingDirectory=/path/to/llm-council
+Environment="PATH=/path/to/llm-council/.venv/bin:/usr/bin"
+ExecStart=/path/to/llm-council/.venv/bin/python -m backend.discord_bot
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start the service:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable llm-council-bot
+sudo systemctl start llm-council-bot
+
+# Check status
+sudo systemctl status llm-council-bot
+
+# View logs
+sudo journalctl -u llm-council-bot -f
+```
+
+## Step 6: Usage in Discord
+
+### Commands
+
+**Submit a question:**
+```
+!council What are the key differences between async and threading in Python?
+```
+
+**Mention the bot:**
+```
+@LLMCouncil Explain quantum computing in simple terms
+```
+
+**Get help:**
+```
+!help_council
+```
+
+### How It Works
+
+1. **Thread Creation:** The bot creates a thread for each question to keep things organized
+2. **Stage 1:** Individual responses from all council members (shown in blue embeds)
+3. **Stage 2:** Peer reviews and rankings (shown in orange embeds)
+4. **Aggregate Rankings:** Summary of which models performed best
+5. **Stage 3:** Final synthesis from Chairman (shown in green embed)
+
+## Data Storage
+
+Conversations are stored in:
+```
+data/discord_channels/{channel_id}.json
+```
+
+Each file contains:
+- Channel ID and name
+- All questions asked in that channel
+- Complete stage 1, 2, 3 results
+- User information (ID, username)
+
+You can back these up or analyze them later.
+
+## Troubleshooting
+
+### Bot doesn't respond
+
+1. **Check if bot is running:**
+   ```bash
+   systemctl status llm-council-bot
+   # or
+   tmux ls
+   ```
+
+2. **Check logs:**
+   ```bash
+   journalctl -u llm-council-bot -n 50
+   ```
+
+3. **Verify permissions:** Make sure bot has Send Messages and Create Threads permissions in the channel
+
+### Rate limiting errors
+
+Discord has rate limits. The bot includes small delays between messages (`asyncio.sleep(0.5)`). If you hit limits:
+- Reduce council size (fewer models = fewer messages)
+- Increase delays in `discord_bot.py`
+
+### Model errors
+
+If specific models fail:
+- Check OpenRouter status and credits
+- Remove problematic models from `COUNCIL_MODELS` in `config.py`
+- The system gracefully handles failures (continues with successful responses)
+
+### Environment issues on NAS
+
+Some NAS systems (Synology, QNAP) have quirks:
+
+1. **Python version:** Make sure you have Python 3.10+
+   ```bash
+   python3 --version
+   ```
+
+2. **Path issues:** Use absolute paths in systemd service file
+
+3. **Permissions:** Make sure your user can access the project directory
+
+## Cost Optimization
+
+Each council query costs money on OpenRouter. To reduce costs:
+
+1. **Fewer council members:**
+   ```python
+   COUNCIL_MODELS = [
+       "openai/gpt-5.1",
+       "anthropic/claude-sonnet-4.5",
+   ]
+   ```
+
+2. **Use cheaper chairman:**
+   ```python
+   CHAIRMAN_MODEL = "anthropic/claude-sonnet-4.5"  # Instead of Opus
+   ```
+
+3. **Monitor usage:** Check your OpenRouter dashboard regularly
+
+4. **Limit users:** Only allow certain Discord roles to use the bot (modify `discord_bot.py` to add permission checks)
+
+## Advanced: Permission Control
+
+To restrict bot usage to specific roles, add this to `discord_bot.py`:
+
+```python
+@bot.command(name='council', help='Submit a question to the LLM Council')
+@commands.has_role("Council Member")  # Only users with this role can use it
+async def council_command(ctx, *, question: str):
+    await process_council_query(ctx, question)
+```
+
+Or check in the command:
+```python
+async def process_council_query(ctx, question: str):
+    # Check if user has required role
+    allowed_role = discord.utils.get(ctx.guild.roles, name="Council Member")
+    if allowed_role not in ctx.author.roles:
+        await ctx.send("❌ You don't have permission to use the Council.")
+        return
+
+    # ... rest of code
+```
+
+## Stopping the Bot
+
+**If using tmux:**
+```bash
+tmux attach -t council-bot
+# Press Ctrl+C to stop
+```
+
+**If using systemd:**
+```bash
+sudo systemctl stop llm-council-bot
+```
+
+## Updates
+
+To update the bot after making changes:
+
+```bash
+# Pull latest code (if using git)
+git pull
+
+# Restart the service
+sudo systemctl restart llm-council-bot
+```
+
+---
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Start bot (manual) | `uv run python -m backend.discord_bot` |
+| Start service | `sudo systemctl start llm-council-bot` |
+| Stop service | `sudo systemctl stop llm-council-bot` |
+| View logs | `sudo journalctl -u llm-council-bot -f` |
+| Check status | `sudo systemctl status llm-council-bot` |
+| Discord command | `!council <your question>` |
+| Discord mention | `@LLMCouncil <your question>` |
+
+---
+
+Enjoy your Discord-based LLM Council! 🏛️

--- a/backend/config.py
+++ b/backend/config.py
@@ -9,15 +9,17 @@ load_dotenv()
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 
 # Council members - list of OpenRouter model identifiers
+# NOTE: For Discord bot, you can use fewer models to reduce costs
 COUNCIL_MODELS = [
     "openai/gpt-5.1",
     "google/gemini-3-pro-preview",
     "anthropic/claude-sonnet-4.5",
-    "x-ai/grok-4",
+    # "x-ai/grok-4",  # Uncomment to add more council members
 ]
 
 # Chairman model - synthesizes final response
-CHAIRMAN_MODEL = "google/gemini-3-pro-preview"
+# Opus 4.1 recommended for high-quality synthesis
+CHAIRMAN_MODEL = "anthropic/claude-opus-4.1"
 
 # OpenRouter API endpoint
 OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"

--- a/backend/discord_bot.py
+++ b/backend/discord_bot.py
@@ -1,0 +1,305 @@
+"""Discord bot for LLM Council."""
+
+import discord
+from discord.ext import commands
+import os
+from dotenv import load_dotenv
+import asyncio
+from typing import List, Dict, Any
+
+from .council import run_full_council
+from .storage import get_conversation, create_conversation, add_user_message, add_assistant_message
+
+load_dotenv()
+
+# Bot setup
+intents = discord.Intents.default()
+intents.message_content = True
+intents.messages = True
+
+bot = commands.Bot(command_prefix='!', intents=intents)
+
+# Discord message length limit
+MAX_MESSAGE_LENGTH = 2000
+
+
+def split_message(text: str, max_length: int = MAX_MESSAGE_LENGTH) -> List[str]:
+    """
+    Split a long message into chunks that fit Discord's limit.
+
+    Args:
+        text: The text to split
+        max_length: Maximum length per chunk
+
+    Returns:
+        List of text chunks
+    """
+    if len(text) <= max_length:
+        return [text]
+
+    chunks = []
+    current_chunk = ""
+
+    for line in text.split('\n'):
+        if len(current_chunk) + len(line) + 1 > max_length:
+            if current_chunk:
+                chunks.append(current_chunk)
+                current_chunk = line
+            else:
+                # Single line is too long, split it
+                for i in range(0, len(line), max_length):
+                    chunks.append(line[i:i + max_length])
+        else:
+            current_chunk += ('\n' if current_chunk else '') + line
+
+    if current_chunk:
+        chunks.append(current_chunk)
+
+    return chunks
+
+
+def create_stage1_embed(model: str, response: str, index: int, total: int) -> discord.Embed:
+    """Create an embed for a Stage 1 response."""
+    # Truncate if needed (embed descriptions have 4096 char limit)
+    truncated = response[:4000] + "..." if len(response) > 4000 else response
+
+    embed = discord.Embed(
+        title=f"📝 Stage 1: Individual Response ({index}/{total})",
+        description=truncated,
+        color=discord.Color.blue()
+    )
+    embed.set_footer(text=f"Model: {model}")
+    return embed
+
+
+def create_stage2_embed(model: str, ranking: str, parsed_ranking: List[str], index: int, total: int) -> discord.Embed:
+    """Create an embed for a Stage 2 ranking."""
+    # Truncate if needed
+    truncated = ranking[:4000] + "..." if len(ranking) > 4000 else ranking
+
+    embed = discord.Embed(
+        title=f"🎯 Stage 2: Peer Review ({index}/{total})",
+        description=truncated,
+        color=discord.Color.orange()
+    )
+
+    # Add parsed ranking as field
+    if parsed_ranking:
+        ranking_text = "\n".join([f"{i+1}. {label}" for i, label in enumerate(parsed_ranking)])
+        embed.add_field(name="Extracted Ranking", value=ranking_text, inline=False)
+
+    embed.set_footer(text=f"Reviewer: {model}")
+    return embed
+
+
+def create_stage3_embed(model: str, response: str) -> discord.Embed:
+    """Create an embed for the Stage 3 final synthesis."""
+    # Truncate if needed
+    truncated = response[:4000] + "..." if len(response) > 4000 else response
+
+    embed = discord.Embed(
+        title="✅ Stage 3: Final Synthesis",
+        description=truncated,
+        color=discord.Color.green()
+    )
+    embed.set_footer(text=f"Chairman: {model}")
+    return embed
+
+
+def create_aggregate_rankings_embed(rankings: List[Dict[str, Any]]) -> discord.Embed:
+    """Create an embed showing aggregate rankings."""
+    embed = discord.Embed(
+        title="📊 Aggregate Rankings",
+        description="Average ranking across all peer reviews (lower is better):",
+        color=discord.Color.purple()
+    )
+
+    for i, rank_data in enumerate(rankings, 1):
+        model = rank_data['model']
+        avg_rank = rank_data['average_rank']
+        count = rank_data['rankings_count']
+
+        embed.add_field(
+            name=f"{i}. {model}",
+            value=f"Average Position: **{avg_rank}** ({count} votes)",
+            inline=False
+        )
+
+    return embed
+
+
+@bot.event
+async def on_ready():
+    """Called when the bot is ready."""
+    print(f'✅ Bot logged in as {bot.user.name} (ID: {bot.user.id})')
+    print(f'🎯 Ready to receive council queries!')
+    print('---')
+
+
+@bot.command(name='council', help='Submit a question to the LLM Council')
+async def council_command(ctx, *, question: str):
+    """
+    Main command to run the LLM Council.
+
+    Usage: !council <your question>
+    """
+    await process_council_query(ctx, question)
+
+
+async def process_council_query(ctx, question: str):
+    """Process a council query and send results to Discord."""
+    # Create a thread for this query to keep things organized
+    thread_name = question[:100] if len(question) <= 100 else question[:97] + "..."
+
+    try:
+        # Send initial message
+        initial_msg = await ctx.send(f"🤔 **Consulting the LLM Council...**\nQuestion: {question}")
+
+        # Create thread
+        thread = await initial_msg.create_thread(name=thread_name)
+
+        # Send processing message
+        await thread.send("⏳ Stage 1: Collecting individual responses from council members...")
+
+        # Run the full council process
+        stage1_results, stage2_results, stage3_result, metadata = await run_full_council(question)
+
+        # Check for errors
+        if not stage1_results:
+            await thread.send("❌ All models failed to respond. Please try again later.")
+            return
+
+        # === STAGE 1: Individual Responses ===
+        await thread.send("### 📝 Stage 1: Individual Responses")
+
+        for idx, result in enumerate(stage1_results, 1):
+            embed = create_stage1_embed(
+                model=result['model'],
+                response=result['response'],
+                index=idx,
+                total=len(stage1_results)
+            )
+            await thread.send(embed=embed)
+            await asyncio.sleep(0.5)  # Small delay to avoid rate limits
+
+        # === STAGE 2: Peer Reviews ===
+        await thread.send("\n⏳ Stage 2: Collecting peer reviews and rankings...")
+        await thread.send("### 🎯 Stage 2: Peer Reviews")
+
+        for idx, result in enumerate(stage2_results, 1):
+            embed = create_stage2_embed(
+                model=result['model'],
+                ranking=result['ranking'],
+                parsed_ranking=result.get('parsed_ranking', []),
+                index=idx,
+                total=len(stage2_results)
+            )
+            await thread.send(embed=embed)
+            await asyncio.sleep(0.5)
+
+        # Show aggregate rankings
+        if metadata.get('aggregate_rankings'):
+            aggregate_embed = create_aggregate_rankings_embed(metadata['aggregate_rankings'])
+            await thread.send(embed=aggregate_embed)
+
+        # === STAGE 3: Final Synthesis ===
+        await thread.send("\n⏳ Stage 3: Chairman synthesizing final answer...")
+        await thread.send("### ✅ Stage 3: Final Answer")
+
+        embed = create_stage3_embed(
+            model=stage3_result['model'],
+            response=stage3_result['response']
+        )
+        await thread.send(embed=embed)
+
+        # Final completion message
+        await thread.send("---\n✨ **Council deliberation complete!**")
+
+    except Exception as e:
+        error_msg = f"❌ An error occurred: {str(e)}"
+        print(f"Error in process_council_query: {e}")
+
+        # Try to send error to thread if it exists, otherwise to channel
+        try:
+            if 'thread' in locals():
+                await thread.send(error_msg)
+            else:
+                await ctx.send(error_msg)
+        except:
+            await ctx.send(error_msg)
+
+
+@bot.event
+async def on_message(message):
+    """Handle mentions of the bot."""
+    # Ignore bot's own messages
+    if message.author == bot.user:
+        return
+
+    # Process commands first
+    await bot.process_commands(message)
+
+    # If bot is mentioned (but not a command), treat as council query
+    if bot.user.mentioned_in(message) and not message.mention_everyone:
+        # Remove the mention from the message
+        question = message.content.replace(f'<@{bot.user.id}>', '').strip()
+        question = message.content.replace(f'<@!{bot.user.id}>', '').strip()
+
+        if question:
+            await process_council_query(message, question)
+
+
+@bot.command(name='help_council', help='Show help for the LLM Council bot')
+async def help_council(ctx):
+    """Display help information."""
+    help_embed = discord.Embed(
+        title="🏛️ LLM Council Bot - Help",
+        description="A multi-stage deliberation system where multiple LLMs collaboratively answer your questions.",
+        color=discord.Color.blue()
+    )
+
+    help_embed.add_field(
+        name="How to Use",
+        value=(
+            "**Method 1:** Use the command\n"
+            "`!council <your question>`\n\n"
+            "**Method 2:** Mention the bot\n"
+            "`@LLMCouncil <your question>`"
+        ),
+        inline=False
+    )
+
+    help_embed.add_field(
+        name="How It Works",
+        value=(
+            "**Stage 1:** All council members respond individually\n"
+            "**Stage 2:** Each member reviews and ranks all responses (anonymized)\n"
+            "**Stage 3:** The Chairman synthesizes a final answer"
+        ),
+        inline=False
+    )
+
+    help_embed.add_field(
+        name="Example",
+        value="`!council What are the key differences between async and threading in Python?`",
+        inline=False
+    )
+
+    await ctx.send(embed=help_embed)
+
+
+def main():
+    """Run the Discord bot."""
+    token = os.getenv('DISCORD_BOT_TOKEN')
+
+    if not token:
+        print("❌ Error: DISCORD_BOT_TOKEN not found in environment variables")
+        print("Please add DISCORD_BOT_TOKEN to your .env file")
+        return
+
+    print("🚀 Starting Discord Council Bot...")
+    bot.run(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/storage.py
+++ b/backend/storage.py
@@ -1,4 +1,4 @@
-"""JSON-based storage for conversations."""
+"""JSON-based storage for conversations and Discord channels."""
 
 import json
 import os
@@ -6,6 +6,9 @@ from datetime import datetime
 from typing import List, Dict, Any, Optional
 from pathlib import Path
 from .config import DATA_DIR
+
+# Discord-specific data directory
+DISCORD_DATA_DIR = "data/discord_channels"
 
 
 def ensure_data_dir():
@@ -170,3 +173,146 @@ def update_conversation_title(conversation_id: str, title: str):
 
     conversation["title"] = title
     save_conversation(conversation)
+
+
+# ============================================================================
+# Discord-specific storage functions
+# ============================================================================
+
+def ensure_discord_dir():
+    """Ensure the Discord data directory exists."""
+    Path(DISCORD_DATA_DIR).mkdir(parents=True, exist_ok=True)
+
+
+def get_discord_channel_path(channel_id: str) -> str:
+    """Get the file path for a Discord channel conversation."""
+    return os.path.join(DISCORD_DATA_DIR, f"{channel_id}.json")
+
+
+def get_discord_channel(channel_id: str) -> Optional[Dict[str, Any]]:
+    """
+    Load a Discord channel conversation from storage.
+
+    Args:
+        channel_id: Discord channel ID
+
+    Returns:
+        Channel conversation dict or None if not found
+    """
+    path = get_discord_channel_path(channel_id)
+
+    if not os.path.exists(path):
+        return None
+
+    with open(path, 'r') as f:
+        return json.load(f)
+
+
+def create_discord_channel(channel_id: str, channel_name: str = "Unknown Channel") -> Dict[str, Any]:
+    """
+    Create a new Discord channel conversation.
+
+    Args:
+        channel_id: Discord channel ID
+        channel_name: Name of the Discord channel
+
+    Returns:
+        New channel conversation dict
+    """
+    ensure_discord_dir()
+
+    channel_data = {
+        "channel_id": channel_id,
+        "channel_name": channel_name,
+        "created_at": datetime.utcnow().isoformat(),
+        "messages": []
+    }
+
+    # Save to file
+    path = get_discord_channel_path(channel_id)
+    with open(path, 'w') as f:
+        json.dump(channel_data, f, indent=2)
+
+    return channel_data
+
+
+def save_discord_channel(channel_data: Dict[str, Any]):
+    """
+    Save a Discord channel conversation to storage.
+
+    Args:
+        channel_data: Channel conversation dict to save
+    """
+    ensure_discord_dir()
+
+    path = get_discord_channel_path(channel_data['channel_id'])
+    with open(path, 'w') as f:
+        json.dump(channel_data, f, indent=2)
+
+
+def add_discord_message(
+    channel_id: str,
+    user_id: str,
+    user_name: str,
+    question: str,
+    stage1: List[Dict[str, Any]],
+    stage2: List[Dict[str, Any]],
+    stage3: Dict[str, Any]
+):
+    """
+    Add a complete council interaction to a Discord channel.
+
+    Args:
+        channel_id: Discord channel ID
+        user_id: Discord user ID who asked the question
+        user_name: Discord username
+        question: The user's question
+        stage1: Stage 1 results
+        stage2: Stage 2 results
+        stage3: Stage 3 result
+    """
+    # Get or create channel data
+    channel_data = get_discord_channel(channel_id)
+    if channel_data is None:
+        channel_data = create_discord_channel(channel_id)
+
+    # Add the interaction
+    channel_data["messages"].append({
+        "timestamp": datetime.utcnow().isoformat(),
+        "user_id": user_id,
+        "user_name": user_name,
+        "question": question,
+        "stage1": stage1,
+        "stage2": stage2,
+        "stage3": stage3
+    })
+
+    save_discord_channel(channel_data)
+
+
+def list_discord_channels() -> List[Dict[str, Any]]:
+    """
+    List all Discord channels with conversation history.
+
+    Returns:
+        List of channel metadata dicts
+    """
+    ensure_discord_dir()
+
+    channels = []
+    for filename in os.listdir(DISCORD_DATA_DIR):
+        if filename.endswith('.json'):
+            path = os.path.join(DISCORD_DATA_DIR, filename)
+            with open(path, 'r') as f:
+                data = json.load(f)
+                channels.append({
+                    "channel_id": data["channel_id"],
+                    "channel_name": data.get("channel_name", "Unknown"),
+                    "created_at": data["created_at"],
+                    "message_count": len(data["messages"])
+                })
+
+    # Sort by creation time, newest first
+    channels.sort(key=lambda x: x["created_at"], reverse=True)
+
+    return channels

--- a/discord-requirements.txt
+++ b/discord-requirements.txt
@@ -1,0 +1,6 @@
+# Discord Bot Requirements
+# Install with: pip install -r discord-requirements.txt
+
+discord.py>=2.3.2
+httpx>=0.25.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
This commit adds a complete Discord bot interface as an alternative to the web UI, allowing the LLM Council to run on a NAS or server:

- backend/discord_bot.py: Full Discord bot with command handling, thread creation, and embed formatting
- backend/storage.py: Added Discord channel-based storage functions
- backend/config.py: Updated to use Claude Opus 4.1 as chairman, reduced council size for cost efficiency
- DISCORD_SETUP.md: Comprehensive setup guide for Discord bot deployment
- discord-requirements.txt: Dependencies for Discord bot

Key features:
- Reuses 100% of existing council.py logic (stages 1-3)
- Creates threads per query for organized discussions
- Beautiful Discord embeds for each stage
- Handles Discord message limits automatically
- JSON storage per Discord channel
- Supports both !council command and @mentions

Perfect for running on a NAS without the web frontend.