### PR TITLE
Replace uv with pip for package management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ wheels/
 
 # Virtual environments
 .venv
+venv
 
 # Keys and secrets
 .env

--- a/README.md
+++ b/README.md
@@ -18,11 +18,14 @@ This project was 99% vibe coded as a fun Saturday hack because I wanted to explo
 
 ### 1. Install Dependencies
 
-The project uses [uv](https://docs.astral.sh/uv/) for project management.
-
 **Backend:**
 ```bash
-uv sync
+# Create a virtual environment (recommended)
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+
+# Install Python dependencies
+pip install -r requirements.txt
 ```
 
 **Frontend:**
@@ -68,7 +71,9 @@ CHAIRMAN_MODEL = "google/gemini-3-pro-preview"
 
 Terminal 1 (Backend):
 ```bash
-uv run python -m backend.main
+# Make sure your virtual environment is activated
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+python -m backend.main
 ```
 
 Terminal 2 (Frontend):
@@ -84,4 +89,4 @@ Then open http://localhost:5173 in your browser.
 - **Backend:** FastAPI (Python 3.10+), async httpx, OpenRouter API
 - **Frontend:** React + Vite, react-markdown for rendering
 - **Storage:** JSON files in `data/conversations/`
-- **Package Management:** uv for Python, npm for JavaScript
+- **Package Management:** pip for Python, npm for JavaScript

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# LLM Council Python Dependencies
+# Install with: pip install -r requirements.txt
+
+fastapi>=0.115.0
+uvicorn[standard]>=0.32.0
+python-dotenv>=1.0.0
+httpx>=0.27.0
+pydantic>=2.9.0

--- a/start.sh
+++ b/start.sh
@@ -7,7 +7,7 @@ echo ""
 
 # Start backend
 echo "Starting backend on http://localhost:8001..."
-uv run python -m backend.main &
+python -m backend.main &
 BACKEND_PID=$!
 
 # Wait a bit for backend to start


### PR DESCRIPTION
- Add requirements.txt with project dependencies
- Update start.sh to use python instead of uv run
- Update README.md with pip installation instructions
- Update .gitignore to include venv directory

This change makes the project compatible with standard pip/venv workflow for environments where uv cannot be installed.