### PR TITLE
Fix text overflow on chat interface

### DIFF
--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -161,3 +161,31 @@
   background: #ccc;
   border-color: #ccc;
 }
+
+/* Contain conversation and force wrapping */
+.chat-interface, .chat-container, .conversation, .messages {
+    max-width: 100%;
+    overflow-x: hidden; /* important: stop children from creating horizontal scroll */
+}
+
+/* Make each message wrap instead of expanding */
+.message, .message-bubble, .chat-message {
+    max-width: calc(100% - 48px); /* leave room for padding/avatar */
+    word-break: break-word;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap; /* preserve line breaks but allow wrapping */
+    hyphens: auto;
+    box-sizing: border-box;
+}
+
+/* Prevent media from overflowing */
+.message img, .message video, .message iframe {
+    max-width: 100%;
+    height: auto;
+    display: block;
+}
+
+/* If using flex rows, allow shrinking */
+.message-row, .message-wrapper {
+    min-width: 0; /* allows flex children to shrink instead of overflowing */
+}

--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -9,7 +9,9 @@
 .messages-container {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 24px;
+  max-width: 100%;
 }
 
 .empty-state {
@@ -60,6 +62,8 @@
   line-height: 1.6;
   max-width: 80%;
   white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .loading-indicator {
@@ -160,32 +164,4 @@
   cursor: not-allowed;
   background: #ccc;
   border-color: #ccc;
-}
-
-/* Contain conversation and force wrapping */
-.chat-interface, .chat-container, .conversation, .messages {
-    max-width: 100%;
-    overflow-x: hidden; /* important: stop children from creating horizontal scroll */
-}
-
-/* Make each message wrap instead of expanding */
-.message, .message-bubble, .chat-message {
-    max-width: calc(100% - 48px); /* leave room for padding/avatar */
-    word-break: break-word;
-    overflow-wrap: anywhere;
-    white-space: pre-wrap; /* preserve line breaks but allow wrapping */
-    hyphens: auto;
-    box-sizing: border-box;
-}
-
-/* Prevent media from overflowing */
-.message img, .message video, .message iframe {
-    max-width: 100%;
-    height: auto;
-    display: block;
-}
-
-/* If using flex rows, allow shrinking */
-.message-row, .message-wrapper {
-    min-width: 0; /* allows flex children to shrink instead of overflowing */
 }

--- a/frontend/src/components/Stage1.css
+++ b/frontend/src/components/Stage1.css
@@ -50,6 +50,9 @@
   padding: 16px;
   border-radius: 6px;
   border: 1px solid #e0e0e0;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .model-name {
@@ -62,4 +65,6 @@
 .response-text {
   color: #333;
   line-height: 1.6;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }

--- a/frontend/src/components/Stage2.css
+++ b/frontend/src/components/Stage2.css
@@ -109,6 +109,9 @@
   border-radius: 6px;
   border: 1px solid #e0e0e0;
   margin-bottom: 20px;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .ranking-model {
@@ -122,6 +125,8 @@
   color: #333;
   line-height: 1.6;
   font-size: 14px;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .parsed-ranking {

--- a/frontend/src/components/Stage3.css
+++ b/frontend/src/components/Stage3.css
@@ -8,6 +8,9 @@
   padding: 20px;
   border-radius: 6px;
   border: 1px solid #c8e6c8;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .chairman-label {
@@ -22,4 +25,6 @@
   color: #333;
   line-height: 1.7;
   font-size: 15px;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,15 +15,6 @@
   box-sizing: border-box;
 }
 
-html, body, #root {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-    /* prevent any accidental horizontal scroll from 100vw or wide children */
-    overflow-x: hidden;
-    max-width: 100%;
-}
-
 *, *::before, *::after {
     box-sizing: inherit;
 }
@@ -33,7 +24,7 @@ html, body, #root {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
-    overflow-x: hidden; /* ensure no page-level horizontal scroll */
+    overflow-x: hidden;
     max-width: 100%;
 }
 
@@ -58,6 +49,9 @@ body {
 /* Global markdown styling */
 .markdown-content {
   padding: 12px;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .markdown-content p {
@@ -102,6 +96,8 @@ body {
   border-radius: 4px;
   overflow-x: auto;
   margin: 0 0 12px 0;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .markdown-content code {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,6 +15,33 @@
   box-sizing: border-box;
 }
 
+html, body, #root {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    /* prevent any accidental horizontal scroll from 100vw or wide children */
+    overflow-x: hidden;
+    max-width: 100%;
+}
+
+*, *::before, *::after {
+    box-sizing: inherit;
+}
+
+/* Prevent page horizontal overflow and use consistent box-sizing */
+html, body, #root {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    overflow-x: hidden; /* ensure no page-level horizontal scroll */
+    max-width: 100%;
+}
+
+/* Ensure app-level container doesn't overflow */
+#root > .app, .App {
+    overflow-x: hidden;
+}
+
 body {
   margin: 0;
   min-width: 320px;


### PR DESCRIPTION
## Summary

This PR fixes text overflow issues throughout the chat interface by implementing proper word breaking and overflow handling.

## Changes

- Added `word-break: break-word` and `overflow-wrap: anywhere` to all message content areas to prevent long words and URLs from causing horizontal scrolling
- Added overflow protection to all Stage components (Stage1, Stage2, Stage3) for consistent text wrapping
- Enhanced global markdown content styling with proper overflow handling
- Added `max-width: 100%` to code blocks to prevent them from breaking the layout
- Removed dead CSS rules that targeted non-existent classes
- Cleaned up duplicate CSS declarations in index.css

## Testing

All message types (user messages, stage responses, markdown content, code blocks) now properly wrap long content instead of causing horizontal scroll.

Related to #5 - builds upon the styling improvements with additional overflow fixes.