### PR TITLE
Feat/configurationsettings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,39 @@
 # Python-generated files
 __pycache__/
 *.py[oc]
+*.pyo
+*.pyd
+*.so
+*.egg-info
 build/
 dist/
 wheels/
-*.egg-info
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+coverage.xml
+htmlcov/
 
 # Virtual environments
 .venv
-
-# Keys and secrets
 .env
+.env.*
+.python-version
+
+# Logs and local artifacts
+*.log
+*.log.*
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# OS / editor cruft
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
 
 # Data files
 data/
@@ -19,3 +42,6 @@ data/
 frontend/node_modules/
 frontend/dist/
 frontend/.vite/
+frontend/.eslintcache
+frontend/.turbo
+frontend/.parcel-cache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# CLAUDE.md - Technical Notes for LLM Council
+# AGENTS.md - Technical Notes for LLM Council
 
 This file contains technical details, architectural decisions, and important implementation notes for future development sessions.
 

--- a/README.md
+++ b/README.md
@@ -42,20 +42,15 @@ OPENROUTER_API_KEY=sk-or-v1-...
 
 Get your API key at [openrouter.ai](https://openrouter.ai/). Make sure to purchase the credits you need, or sign up for automatic top up.
 
-### 3. Configure Models (Optional)
+### 3. Configure Models (via UI)
 
-Edit `backend/config.py` to customize the council:
+You can now select council members and the chairman from the Settings panel (gear icon, bottom-right):
 
-```python
-COUNCIL_MODELS = [
-    "openai/gpt-5.1",
-    "google/gemini-3-pro-preview",
-    "anthropic/claude-sonnet-4.5",
-    "x-ai/grok-4",
-]
+- Backend loads/saves choices in `data/settings.json` via `/api/settings`.
+- Available models come from OpenRouter `/models` (cached with fallback to `data/availablemodels/openrouter.json`).
+- The UI lets you pick human-readable names (e.g., “Anthropic: Claude Opus 4.5”) while using the OpenRouter model `id` under the hood.
 
-CHAIRMAN_MODEL = "google/gemini-3-pro-preview"
-```
+If you prefer static defaults, `backend/config.py` still provides the initial values used when no saved settings exist.
 
 ## Running the Application
 

--- a/backend/model_catalog.py
+++ b/backend/model_catalog.py
@@ -1,0 +1,111 @@
+"""Model catalog utilities for OpenRouter models."""
+
+import json
+import os
+import time
+from typing import Any, Dict, List, Literal, Optional, Tuple
+
+import httpx
+
+from .config import OPENROUTER_API_KEY
+
+SNAPSHOT_PATH = os.path.join("data", "availablemodels", "openrouter.json")
+OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+
+_cache: Dict[str, Any] | None = None
+_cache_expiry: float = 0
+_CACHE_TTL_SECONDS = 600  # 10 minutes
+
+
+def _transform_model(record: Dict[str, Any]) -> Dict[str, Any]:
+  """Normalize a model record for UI consumption."""
+  model_id = record.get("id")
+  label = record.get("label") or record.get("name") or model_id
+  top_provider = record.get("top_provider", {}) or {}
+  pricing = record.get("pricing", {}) or {}
+  return {
+      "id": model_id,
+      "label": label,
+      "context_length": top_provider.get("context_length"),
+      "max_completion_tokens": top_provider.get("max_completion_tokens"),
+      "is_moderated": top_provider.get("is_moderated"),
+      "pricing": {
+          "prompt": pricing.get("prompt"),
+          "completion": pricing.get("completion"),
+      },
+  }
+
+
+def _load_snapshot() -> Optional[List[Dict[str, Any]]]:
+  """Load the local snapshot file if present."""
+  if not os.path.exists(SNAPSHOT_PATH):
+    return None
+  try:
+    with open(SNAPSHOT_PATH, "r", encoding="utf-8") as f:
+      payload = json.load(f)
+    data = payload.get("data") or []
+    return [_transform_model(item) for item in data if item.get("id")]
+  except Exception:
+    return None
+
+
+async def _fetch_live_models(timeout: float = 3.0) -> Optional[List[Dict[str, Any]]]:
+  """Fetch live models from OpenRouter."""
+  if not OPENROUTER_API_KEY:
+    return None
+
+  headers = {
+      "Authorization": f"Bearer {OPENROUTER_API_KEY}",
+  }
+  try:
+    async with httpx.AsyncClient(timeout=timeout) as client:
+      resp = await client.get(OPENROUTER_MODELS_URL, headers=headers)
+      resp.raise_for_status()
+      payload = resp.json()
+      data = payload.get("data") or []
+      return [_transform_model(item) for item in data if item.get("id")]
+  except Exception as e:
+    print(f"Warning: failed to fetch OpenRouter models: {e}")
+    return None
+
+
+async def get_models(
+    force_refresh: bool = False,
+) -> Tuple[List[Dict[str, Any]], Literal["live", "cache", "fallback"]]:
+  """
+  Retrieve available models, preferring live data, then cache, then local snapshot.
+
+  Returns (models, source) where source is "live", "cache", or "fallback".
+  """
+  global _cache, _cache_expiry
+  now = time.time()
+
+  if _cache and _cache_expiry > now and not force_refresh:
+    return _cache, "cache"
+
+  models = await _fetch_live_models()
+  source: Literal["live", "cache", "fallback"]
+
+  if models:
+    _cache = models
+    _cache_expiry = now + _CACHE_TTL_SECONDS
+    source = "live"
+    # Persist live data to snapshot for offline use
+    try:
+      os.makedirs(os.path.dirname(SNAPSHOT_PATH), exist_ok=True)
+      with open(SNAPSHOT_PATH, "w", encoding="utf-8") as f:
+        json.dump({"data": models}, f, indent=2)
+    except Exception:
+      pass
+    return models, source
+
+  # If no live data, try cache (if present but expired)
+  if _cache:
+    source = "cache"
+    return _cache, source
+
+  snapshot = _load_snapshot() or []
+  source = "fallback"
+  _cache = snapshot
+  _cache_expiry = now + _CACHE_TTL_SECONDS
+  return snapshot, source

--- a/backend/settings_service.py
+++ b/backend/settings_service.py
@@ -1,0 +1,71 @@
+"""Manage runtime settings for council models."""
+
+import json
+import os
+from typing import Dict, List, Tuple
+
+from .config import COUNCIL_MODELS, CHAIRMAN_MODEL
+
+SETTINGS_PATH = os.path.join("data", "settings.json")
+
+_settings_cache: Dict[str, List[str] | str] | None = None
+
+
+def _ensure_data_dir():
+  os.makedirs(os.path.dirname(SETTINGS_PATH), exist_ok=True)
+
+
+def load_settings() -> Dict[str, List[str] | str]:
+  """Load settings from disk or fall back to defaults."""
+  global _settings_cache
+  if _settings_cache is not None:
+    return _settings_cache
+
+  defaults = {
+      "council_models": COUNCIL_MODELS,
+      "chairman_model": CHAIRMAN_MODEL,
+  }
+
+  if not os.path.exists(SETTINGS_PATH):
+    _settings_cache = defaults
+    return defaults
+
+  try:
+    with open(SETTINGS_PATH, "r", encoding="utf-8") as f:
+      data = json.load(f)
+      council_models = data.get("council_models", COUNCIL_MODELS)
+      chairman_model = data.get("chairman_model", CHAIRMAN_MODEL)
+      _settings_cache = {
+          "council_models": council_models,
+          "chairman_model": chairman_model,
+      }
+      return _settings_cache
+  except Exception:
+    # If parsing fails, fall back to defaults
+    _settings_cache = defaults
+    return defaults
+
+
+def save_settings(council_models: List[str], chairman_model: str) -> Dict[str, List[str] | str]:
+  """Persist settings to disk and cache."""
+  global _settings_cache
+  _ensure_data_dir()
+  settings = {
+      "council_models": council_models,
+      "chairman_model": chairman_model,
+  }
+  with open(SETTINGS_PATH, "w", encoding="utf-8") as f:
+    json.dump(settings, f, indent=2)
+  _settings_cache = settings
+  return settings
+
+
+def get_settings() -> Dict[str, List[str] | str]:
+  """Get the current settings, loading from disk if necessary."""
+  return load_settings()
+
+
+def reset_cache():
+  """Reset in-memory cache (useful for tests)."""
+  global _settings_cache
+  _settings_cache = None

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <title>LLM Council</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -7,8 +7,8 @@
   height: 100vh;
   width: 100vw;
   overflow: hidden;
-  background: #ffffff;
-  color: #333;
+  background: var(--app-bg);
+  color: var(--text-primary);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import Sidebar from './components/Sidebar';
 import ChatInterface from './components/ChatInterface';
+import ThemeToggle from './components/ThemeToggle';
 import { api } from './api';
 import './App.css';
 
@@ -9,11 +10,21 @@ function App() {
   const [currentConversationId, setCurrentConversationId] = useState(null);
   const [currentConversation, setCurrentConversation] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [theme, setTheme] = useState(() => {
+    if (typeof window === 'undefined') return 'light';
+    return localStorage.getItem('theme') || 'light';
+  });
 
   // Load conversations on mount
   useEffect(() => {
     loadConversations();
   }, []);
+
+  // Sync theme to document + storage
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
 
   // Load conversation details when selected
   useEffect(() => {
@@ -21,6 +32,10 @@ function App() {
       loadConversation(currentConversationId);
     }
   }, [currentConversationId]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
 
   const loadConversations = async () => {
     try {
@@ -182,7 +197,7 @@ function App() {
   };
 
   return (
-    <div className="app">
+    <div className={`app ${theme}`}>
       <Sidebar
         conversations={conversations}
         currentConversationId={currentConversationId}
@@ -194,6 +209,7 @@ function App() {
         onSendMessage={handleSendMessage}
         isLoading={isLoading}
       />
+      <ThemeToggle theme={theme} onToggle={toggleTheme} />
     </div>
   );
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,9 @@
 import { useState, useEffect } from 'react';
 import Sidebar from './components/Sidebar';
 import ChatInterface from './components/ChatInterface';
+import SettingsButton from './components/SettingsButton';
+import SettingsDrawer from './components/SettingsDrawer';
+import { useSettings } from './hooks/useSettings';
 import ThemeToggle from './components/ThemeToggle';
 import { api } from './api';
 import './App.css';
@@ -10,10 +13,12 @@ function App() {
   const [currentConversationId, setCurrentConversationId] = useState(null);
   const [currentConversation, setCurrentConversation] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [theme, setTheme] = useState(() => {
     if (typeof window === 'undefined') return 'light';
     return localStorage.getItem('theme') || 'light';
   });
+  const { settings, updateSettings, resetSettings } = useSettings();
 
   // Load conversations on mount
   useEffect(() => {
@@ -70,6 +75,11 @@ function App() {
 
   const handleSelectConversation = (id) => {
     setCurrentConversationId(id);
+  };
+
+  const handleSaveSettings = (updated) => {
+    updateSettings(updated);
+    setIsSettingsOpen(false);
   };
 
   const handleSendMessage = async (content) => {
@@ -208,6 +218,16 @@ function App() {
         conversation={currentConversation}
         onSendMessage={handleSendMessage}
         isLoading={isLoading}
+      />
+      <SettingsButton onClick={() => setIsSettingsOpen(true)} />
+      <SettingsDrawer
+        isOpen={isSettingsOpen}
+        onClose={() => setIsSettingsOpen(false)}
+        settings={settings}
+        onSave={handleSaveSettings}
+        onReset={() => {
+          resetSettings();
+        }}
       />
       <ThemeToggle theme={theme} onToggle={toggleTheme} />
     </div>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -6,6 +6,48 @@ const API_BASE = 'http://localhost:8001';
 
 export const api = {
   /**
+   * List available models from backend.
+   */
+  async listModels(forceRefresh = false) {
+    const url = new URL(`${API_BASE}/api/models`);
+    if (forceRefresh) {
+      url.searchParams.set('force_refresh', 'true');
+    }
+    const response = await fetch(url.toString());
+    if (!response.ok) {
+      throw new Error('Failed to list models');
+    }
+    return response.json();
+  },
+
+  /**
+   * Get saved council settings.
+   */
+  async getSettings() {
+    const response = await fetch(`${API_BASE}/api/settings`);
+    if (!response.ok) {
+      throw new Error('Failed to load settings');
+    }
+    return response.json();
+  },
+
+  /**
+   * Save council settings.
+   */
+  async saveSettings(payload) {
+    const response = await fetch(`${API_BASE}/api/settings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(message || 'Failed to save settings');
+    }
+    return response.json();
+  },
+
+  /**
    * List all conversations.
    */
   async listConversations() {

--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
-  background: #ffffff;
+  background: var(--surface);
 }
 
 .messages-container {
@@ -18,14 +18,14 @@
   align-items: center;
   justify-content: center;
   height: 100%;
-  color: #666;
+  color: var(--text-secondary);
   text-align: center;
 }
 
 .empty-state h2 {
   margin: 0 0 8px 0;
   font-size: 24px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .empty-state p {
@@ -45,18 +45,18 @@
 .message-label {
   font-size: 12px;
   font-weight: 600;
-  color: #666;
+  color: var(--text-secondary);
   margin-bottom: 8px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
 .user-message .message-content {
-  background: #f0f7ff;
+  background: var(--user-bubble-bg);
   padding: 16px;
   border-radius: 8px;
-  border: 1px solid #d0e7ff;
-  color: #333;
+  border: 1px solid var(--user-bubble-border);
+  color: var(--text-primary);
   line-height: 1.6;
   max-width: 80%;
   white-space: pre-wrap;
@@ -67,7 +67,7 @@
   align-items: center;
   gap: 12px;
   padding: 16px;
-  color: #666;
+  color: var(--text-secondary);
   font-size: 14px;
 }
 
@@ -77,10 +77,10 @@
   gap: 12px;
   padding: 16px;
   margin: 12px 0;
-  background: #f9fafb;
+  background: var(--surface-soft);
   border-radius: 8px;
-  border: 1px solid #e0e0e0;
-  color: #666;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
   font-size: 14px;
   font-style: italic;
 }
@@ -88,8 +88,8 @@
 .spinner {
   width: 20px;
   height: 20px;
-  border: 2px solid #e0e0e0;
-  border-top-color: #4a90e2;
+  border: 2px solid var(--spinner-track);
+  border-top-color: var(--accent);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }
@@ -105,17 +105,17 @@
   align-items: flex-end;
   gap: 12px;
   padding: 24px;
-  border-top: 1px solid #e0e0e0;
-  background: #fafafa;
+  border-top: 1px solid var(--border-color);
+  background: var(--surface-alt);
 }
 
 .message-input {
   flex: 1;
   padding: 14px;
-  background: #ffffff;
-  border: 1px solid #d0d0d0;
+  background: var(--surface);
+  border: 1px solid var(--muted-border);
   border-radius: 8px;
-  color: #333;
+  color: var(--text-primary);
   font-size: 15px;
   font-family: inherit;
   line-height: 1.5;
@@ -126,20 +126,20 @@
 }
 
 .message-input:focus {
-  border-color: #4a90e2;
+  border-color: var(--accent);
   box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.1);
 }
 
 .message-input:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-  background: #f5f5f5;
+  background: var(--input-disabled-bg);
 }
 
 .send-button {
   padding: 14px 28px;
-  background: #4a90e2;
-  border: 1px solid #4a90e2;
+  background: var(--accent);
+  border: 1px solid var(--accent);
   border-radius: 8px;
   color: #fff;
   font-size: 15px;
@@ -151,13 +151,13 @@
 }
 
 .send-button:hover:not(:disabled) {
-  background: #357abd;
-  border-color: #357abd;
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
 }
 
 .send-button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-  background: #ccc;
-  border-color: #ccc;
+  background: var(--muted-border);
+  border-color: var(--muted-border);
 }

--- a/frontend/src/components/SettingsButton.css
+++ b/frontend/src/components/SettingsButton.css
@@ -1,0 +1,34 @@
+.settings-button {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: var(--surface);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-soft);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+  z-index: 20;
+}
+
+.settings-button:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.settings-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-label {
+  white-space: nowrap;
+}

--- a/frontend/src/components/SettingsButton.jsx
+++ b/frontend/src/components/SettingsButton.jsx
@@ -1,0 +1,34 @@
+import './SettingsButton.css';
+
+export default function SettingsButton({ onClick }) {
+  return (
+    <button
+      type="button"
+      className="settings-button"
+      onClick={onClick}
+      aria-label="Open settings"
+    >
+      <span className="settings-icon" aria-hidden="true">
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z"
+            stroke="currentColor"
+            strokeWidth="1.6"
+          />
+          <path
+            d="M19.4 13.7c.1-.55.1-1.14 0-1.7l1.87-1.46c.18-.14.23-.39.12-.6l-1.77-3.06a.46.46 0 0 0-.57-.2l-2.2.89a7.08 7.08 0 0 0-1.46-.85l-.33-2.35a.47.47 0 0 0-.46-.39h-3.54a.47.47 0 0 0-.46.39l-.33 2.35a7.08 7.08 0 0 0-1.46.85l-2.2-.9a.46.46 0 0 0-.57.2L2.6 9.94c-.1.2-.06.45.12.6L4.6 12c-.1.56-.1 1.15 0 1.7l-1.88 1.46a.48.48 0 0 0-.12.6l1.77 3.06c.12.2.38.3.6.2l2.2-.89c.45.35.95.64 1.46.86l.33 2.35c.04.22.23.39.46.39h3.54c.23 0 .42-.17.46-.39l.33-2.35c.51-.22 1-.51 1.46-.86l2.2.9c.22.09.48 0 .6-.2l1.77-3.06a.48.48 0 0 0-.12-.6L19.4 13.7Z"
+            stroke="currentColor"
+            strokeWidth="1.6"
+          />
+        </svg>
+      </span>
+      <span className="settings-label">Settings</span>
+    </button>
+  );
+}

--- a/frontend/src/components/SettingsDrawer.css
+++ b/frontend/src/components/SettingsDrawer.css
@@ -118,13 +118,21 @@
   min-width: 0;
 }
 
-.settings-section input {
+.model-row select {
+  flex: 1;
+  min-width: 0;
+}
+
+.settings-section input,
+.settings-section select {
   width: 100%;
   display: block;
 }
 
 .model-row input,
-.settings-section input {
+.model-row select,
+.settings-section input,
+.settings-section select {
   padding: 12px;
   border: 1px solid var(--muted-border);
   border-radius: 8px;
@@ -134,7 +142,9 @@
 }
 
 .model-row input:focus,
-.settings-section input:focus {
+.model-row select:focus,
+.settings-section input:focus,
+.settings-section select:focus {
   border-color: var(--accent);
   outline: none;
   box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.15);
@@ -150,6 +160,12 @@
   font-weight: 600;
   font-size: 13px;
   transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.ghost-btn.inline {
+  margin-left: 8px;
+  padding: 6px 10px;
+  font-size: 12px;
 }
 
 .ghost-btn:hover {
@@ -198,4 +214,24 @@
 .primary-btn:hover {
   background: var(--accent-strong);
   border-color: var(--accent-strong);
+}
+
+.settings-banner {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.settings-banner.warning {
+  border-color: #e06666;
+  color: #e06666;
+  background: rgba(224, 102, 102, 0.08);
+}
+
+.settings-banner.info {
+  border-color: var(--muted-border);
+  color: var(--text-secondary);
+  background: var(--surface-alt);
 }

--- a/frontend/src/components/SettingsDrawer.css
+++ b/frontend/src/components/SettingsDrawer.css
@@ -1,0 +1,192 @@
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  justify-content: flex-end;
+  align-items: stretch;
+  z-index: 30;
+}
+
+.settings-drawer {
+  width: min(520px, 100%);
+  background: var(--surface);
+  color: var(--text-primary);
+  border-left: 1px solid var(--border-color);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  animation: slideIn 180ms ease-out;
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(10px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.settings-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 20px 24px 12px 24px;
+  border-bottom: 1px solid var(--border-color);
+  gap: 12px;
+}
+
+.settings-header h3 {
+  margin: 0 0 6px 0;
+  font-size: 18px;
+}
+
+.settings-subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.inline-code {
+  margin-left: 4px;
+  padding: 2px 6px;
+  background: var(--code-bg);
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 12px;
+  border: 1px solid var(--border-color);
+}
+
+.close-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  border-radius: 6px;
+  width: 32px;
+  height: 32px;
+  font-size: 18px;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.settings-body {
+  padding: 16px 24px 24px 24px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.settings-section h4 {
+  margin: 0 0 6px 0;
+  font-size: 15px;
+}
+
+.section-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.section-help {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.model-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.model-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.model-row input,
+.settings-section input {
+  flex: 1;
+  padding: 12px;
+  border: 1px solid var(--muted-border);
+  border-radius: 8px;
+  background: var(--surface-alt);
+  color: var(--text-primary);
+  font-size: 14px;
+}
+
+.model-row input:focus,
+.settings-section input:focus {
+  border-color: var(--accent);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(74, 144, 226, 0.15);
+}
+
+.ghost-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 10px 12px;
+  color: var(--text-primary);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 13px;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.ghost-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.ghost-btn.danger:hover {
+  border-color: #e06666;
+  color: #e06666;
+}
+
+.empty-rows {
+  padding: 12px;
+  border: 1px dashed var(--border-color);
+  border-radius: 8px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.settings-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.action-right {
+  display: flex;
+  gap: 8px;
+}
+
+.primary-btn {
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  padding: 10px 14px;
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+  font-size: 13px;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.primary-btn:hover {
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
+}

--- a/frontend/src/components/SettingsDrawer.css
+++ b/frontend/src/components/SettingsDrawer.css
@@ -113,9 +113,18 @@
   align-items: center;
 }
 
+.model-row input {
+  flex: 1;
+  min-width: 0;
+}
+
+.settings-section input {
+  width: 100%;
+  display: block;
+}
+
 .model-row input,
 .settings-section input {
-  flex: 1;
   padding: 12px;
   border: 1px solid var(--muted-border);
   border-radius: 8px;

--- a/frontend/src/components/SettingsDrawer.jsx
+++ b/frontend/src/components/SettingsDrawer.jsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from 'react';
+import './SettingsDrawer.css';
+
+export default function SettingsDrawer({
+  isOpen,
+  onClose,
+  settings,
+  onSave,
+  onReset,
+}) {
+  const [councilModels, setCouncilModels] = useState(settings.councilModels);
+  const [chairmanModel, setChairmanModel] = useState(settings.chairmanModel);
+
+  useEffect(() => {
+    setCouncilModels(settings.councilModels);
+    setChairmanModel(settings.chairmanModel);
+  }, [settings, isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleMemberChange = (index, value) => {
+    setCouncilModels((prev) => {
+      const next = [...prev];
+      next[index] = value;
+      return next;
+    });
+  };
+
+  const handleAddMember = () => {
+    setCouncilModels((prev) => [...prev, '']);
+  };
+
+  const handleRemoveMember = (index) => {
+    setCouncilModels((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSave = (e) => {
+    e.preventDefault();
+    const normalizedCouncil = councilModels
+      .map((m) => m.trim())
+      .filter((m) => m.length > 0);
+    const chairman = chairmanModel.trim() || settings.chairmanModel;
+    onSave({
+      councilModels: normalizedCouncil,
+      chairmanModel: chairman,
+    });
+  };
+
+  return (
+    <div className="settings-overlay" onClick={onClose}>
+      <div
+        className="settings-drawer"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Settings"
+      >
+        <div className="settings-header">
+          <div>
+            <h3>Settings</h3>
+            <p className="settings-subtitle">
+              Configure council members and the chairman model.
+              <br />
+              <strong>Note:</strong> Backend still uses values from
+              <code className="inline-code"> backend/config.py</code>.
+            </p>
+          </div>
+          <button className="close-btn" type="button" onClick={onClose}>
+            ×
+          </button>
+        </div>
+
+        <form className="settings-body" onSubmit={handleSave}>
+          <section className="settings-section">
+            <div className="section-title">
+              <div>
+                <h4>Council members</h4>
+                <p className="section-help">
+                  List of OpenRouter model identifiers. These are the models that will
+                  debate in Stage 1 and rank in Stage 2.
+                </p>
+              </div>
+              <button
+                type="button"
+                className="ghost-btn"
+                onClick={handleAddMember}
+              >
+                + Add member
+              </button>
+            </div>
+
+            <div className="model-list">
+              {councilModels.map((model, index) => (
+                <div className="model-row" key={index}>
+                  <input
+                    type="text"
+                    value={model}
+                    onChange={(e) =>
+                      handleMemberChange(index, e.target.value)
+                    }
+                    placeholder="provider/model-name"
+                  />
+                  <button
+                    type="button"
+                    className="ghost-btn danger"
+                    onClick={() => handleRemoveMember(index)}
+                    aria-label={`Remove council member ${index + 1}`}
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+              {councilModels.length === 0 && (
+                <div className="empty-rows">
+                  No council members. Add at least one model to proceed.
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section className="settings-section">
+            <h4>Chairman model</h4>
+            <p className="section-help">
+              The chairman synthesizes the final Stage 3 answer.
+            </p>
+            <input
+              type="text"
+              value={chairmanModel}
+              onChange={(e) => setChairmanModel(e.target.value)}
+              placeholder="provider/model-name"
+            />
+          </section>
+
+          <section className="settings-section">
+            <h4>Upcoming</h4>
+            <p className="section-help">
+              Next iteration: fetch available models from OpenRouter and persist
+              settings server-side so the backend uses your choices.
+            </p>
+          </section>
+
+          <div className="settings-actions">
+            <button type="button" className="ghost-btn" onClick={onReset}>
+              Reset to defaults
+            </button>
+            <div className="action-right">
+              <button type="button" className="ghost-btn" onClick={onClose}>
+                Cancel
+              </button>
+              <button type="submit" className="primary-btn">
+                Save settings
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -1,7 +1,7 @@
 .sidebar {
   width: 260px;
-  background: #f8f8f8;
-  border-right: 1px solid #e0e0e0;
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
   height: 100vh;
@@ -9,20 +9,20 @@
 
 .sidebar-header {
   padding: 16px;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .sidebar-header h1 {
   font-size: 18px;
   margin: 0 0 12px 0;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .new-conversation-btn {
   width: 100%;
   padding: 10px;
-  background: #4a90e2;
-  border: 1px solid #4a90e2;
+  background: var(--accent);
+  border: 1px solid var(--accent);
   border-radius: 6px;
   color: #fff;
   cursor: pointer;
@@ -32,8 +32,8 @@
 }
 
 .new-conversation-btn:hover {
-  background: #357abd;
-  border-color: #357abd;
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
 }
 
 .conversation-list {
@@ -45,7 +45,7 @@
 .no-conversations {
   padding: 16px;
   text-align: center;
-  color: #999;
+  color: var(--text-muted);
   font-size: 14px;
 }
 
@@ -55,24 +55,25 @@
   border-radius: 6px;
   cursor: pointer;
   transition: background 0.2s;
+  background: transparent;
 }
 
 .conversation-item:hover {
-  background: #f0f0f0;
+  background: var(--surface-alt);
 }
 
 .conversation-item.active {
-  background: #e8f0fe;
-  border: 1px solid #4a90e2;
+  background: var(--surface);
+  border: 1px solid var(--accent);
 }
 
 .conversation-title {
-  color: #333;
+  color: var(--text-primary);
   font-size: 14px;
   margin-bottom: 4px;
 }
 
 .conversation-meta {
-  color: #999;
+  color: var(--text-muted);
   font-size: 12px;
 }

--- a/frontend/src/components/Stage1.css
+++ b/frontend/src/components/Stage1.css
@@ -1,14 +1,14 @@
 .stage {
   margin: 24px 0;
   padding: 20px;
-  background: #fafafa;
+  background: var(--stage-bg);
   border-radius: 8px;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--border-color);
 }
 
 .stage-title {
   margin: 0 0 16px 0;
-  color: #333;
+  color: var(--text-primary);
   font-size: 16px;
   font-weight: 600;
 }
@@ -22,44 +22,44 @@
 
 .tab {
   padding: 8px 16px;
-  background: #ffffff;
-  border: 1px solid #d0d0d0;
+  background: var(--surface);
+  border: 1px solid var(--muted-border);
   border-radius: 6px 6px 0 0;
-  color: #666;
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 14px;
   transition: all 0.2s;
 }
 
 .tab:hover {
-  background: #f0f0f0;
-  color: #333;
-  border-color: #4a90e2;
+  background: var(--surface-alt);
+  color: var(--text-primary);
+  border-color: var(--accent);
 }
 
 .tab.active {
-  background: #ffffff;
-  color: #4a90e2;
-  border-color: #4a90e2;
-  border-bottom-color: #ffffff;
+  background: var(--surface);
+  color: var(--accent);
+  border-color: var(--accent);
+  border-bottom-color: var(--surface);
   font-weight: 600;
 }
 
 .tab-content {
-  background: #ffffff;
+  background: var(--surface);
   padding: 16px;
   border-radius: 6px;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--border-color);
 }
 
 .model-name {
-  color: #888;
+  color: var(--text-muted);
   font-size: 12px;
   margin-bottom: 12px;
   font-family: monospace;
 }
 
 .response-text {
-  color: #333;
+  color: var(--text-primary);
   line-height: 1.6;
 }

--- a/frontend/src/components/Stage2.css
+++ b/frontend/src/components/Stage2.css
@@ -1,10 +1,10 @@
 .stage2 {
-  background: #fafafa;
+  background: var(--stage-bg);
 }
 
 .stage2 h4 {
   margin: 20px 0 8px 0;
-  color: #333;
+  color: var(--text-primary);
   font-size: 14px;
   font-weight: 600;
 }
@@ -15,22 +15,22 @@
 
 .stage-description {
   margin: 0 0 12px 0;
-  color: #666;
+  color: var(--text-secondary);
   font-size: 13px;
   line-height: 1.5;
 }
 
 .aggregate-rankings {
-  background: #f0f7ff;
+  background: var(--aggregate-bg);
   padding: 16px;
   border-radius: 8px;
   margin-bottom: 20px;
-  border: 2px solid #d0e7ff;
+  border: 2px solid var(--aggregate-border);
 }
 
 .aggregate-rankings h4 {
   margin: 0 0 12px 0;
-  color: #2a7ae2;
+  color: var(--accent);
   font-size: 15px;
 }
 
@@ -45,13 +45,13 @@
   align-items: center;
   gap: 12px;
   padding: 10px;
-  background: #ffffff;
+  background: var(--surface);
   border-radius: 6px;
-  border: 1px solid #d0e7ff;
+  border: 1px solid var(--aggregate-border);
 }
 
 .rank-position {
-  color: #2a7ae2;
+  color: var(--accent);
   font-weight: 700;
   font-size: 16px;
   min-width: 35px;
@@ -59,14 +59,14 @@
 
 .rank-model {
   flex: 1;
-  color: #333;
+  color: var(--text-primary);
   font-family: monospace;
   font-size: 14px;
   font-weight: 500;
 }
 
 .rank-score {
-  color: #666;
+  color: var(--text-secondary);
   font-size: 13px;
   font-family: monospace;
 }
@@ -80,46 +80,46 @@
 
 .stage2 .tab {
   padding: 8px 16px;
-  background: #ffffff;
-  border: 1px solid #d0d0d0;
+  background: var(--surface);
+  border: 1px solid var(--muted-border);
   border-radius: 6px 6px 0 0;
-  color: #666;
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 14px;
   transition: all 0.2s;
 }
 
 .stage2 .tab:hover {
-  background: #f0f0f0;
-  color: #333;
-  border-color: #4a90e2;
+  background: var(--surface-alt);
+  color: var(--text-primary);
+  border-color: var(--accent);
 }
 
 .stage2 .tab.active {
-  background: #ffffff;
-  color: #4a90e2;
-  border-color: #4a90e2;
-  border-bottom-color: #ffffff;
+  background: var(--surface);
+  color: var(--accent);
+  border-color: var(--accent);
+  border-bottom-color: var(--surface);
   font-weight: 600;
 }
 
 .stage2 .tab-content {
-  background: #ffffff;
+  background: var(--surface);
   padding: 16px;
   border-radius: 6px;
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--border-color);
   margin-bottom: 20px;
 }
 
 .ranking-model {
-  color: #888;
+  color: var(--text-muted);
   font-size: 12px;
   font-family: monospace;
   margin-bottom: 12px;
 }
 
 .ranking-content {
-  color: #333;
+  color: var(--text-primary);
   line-height: 1.6;
   font-size: 14px;
 }
@@ -127,18 +127,18 @@
 .parsed-ranking {
   margin-top: 16px;
   padding-top: 16px;
-  border-top: 2px solid #e0e0e0;
+  border-top: 2px solid var(--parsed-divider);
 }
 
 .parsed-ranking strong {
-  color: #2a7ae2;
+  color: var(--accent);
   font-size: 13px;
 }
 
 .parsed-ranking ol {
   margin: 8px 0 0 0;
   padding-left: 24px;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .parsed-ranking li {
@@ -148,6 +148,6 @@
 }
 
 .rank-count {
-  color: #999;
+  color: var(--text-muted);
   font-size: 12px;
 }

--- a/frontend/src/components/Stage3.css
+++ b/frontend/src/components/Stage3.css
@@ -1,17 +1,17 @@
 .stage3 {
-  background: #f0fff0;
-  border-color: #c8e6c8;
+  background: var(--stage3-bg);
+  border-color: var(--stage3-border);
 }
 
 .final-response {
-  background: #ffffff;
+  background: var(--surface);
   padding: 20px;
   border-radius: 6px;
-  border: 1px solid #c8e6c8;
+  border: 1px solid var(--stage3-border);
 }
 
 .chairman-label {
-  color: #2d8a2d;
+  color: var(--success);
   font-size: 12px;
   font-family: monospace;
   margin-bottom: 12px;
@@ -19,7 +19,7 @@
 }
 
 .final-text {
-  color: #333;
+  color: var(--text-primary);
   line-height: 1.7;
   font-size: 15px;
 }

--- a/frontend/src/components/ThemeToggle.css
+++ b/frontend/src/components/ThemeToggle.css
@@ -1,0 +1,57 @@
+.theme-toggle {
+  position: fixed;
+  left: 18px;
+  bottom: 18px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: var(--surface);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-soft);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+  z-index: 20;
+}
+
+.theme-toggle:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.toggle-pill {
+  width: 42px;
+  height: 22px;
+  border-radius: 999px;
+  background: var(--border-color);
+  position: relative;
+  transition: background 0.2s ease;
+}
+
+.toggle-pill[data-active="true"] {
+  background: var(--accent);
+}
+
+.toggle-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--surface);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  transition: transform 0.2s ease;
+}
+
+.toggle-pill[data-active="true"] .toggle-thumb {
+  transform: translateX(20px);
+}
+
+.toggle-label {
+  white-space: nowrap;
+}

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -1,0 +1,22 @@
+import './ThemeToggle.css';
+
+export default function ThemeToggle({ theme, onToggle }) {
+  const isDark = theme === 'dark';
+
+  return (
+    <button
+      className="theme-toggle"
+      type="button"
+      onClick={onToggle}
+      aria-pressed={isDark}
+      aria-label="Toggle dark mode"
+    >
+      <span className="toggle-pill" data-active={isDark}>
+        <span className="toggle-thumb" />
+      </span>
+      <span className="toggle-label">
+        {isDark ? 'Dark mode' : 'Light mode'}
+      </span>
+    </button>
+  );
+}

--- a/frontend/src/hooks/useSettings.js
+++ b/frontend/src/hooks/useSettings.js
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useState } from 'react';
+import { DEFAULT_SETTINGS, SETTINGS_STORAGE_KEY } from '../settings/defaults';
+
+const parseStoredSettings = () => {
+  if (typeof window === 'undefined') return DEFAULT_SETTINGS;
+  try {
+    const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
+    if (!stored) return DEFAULT_SETTINGS;
+    const parsed = JSON.parse(stored);
+    return {
+      ...DEFAULT_SETTINGS,
+      ...parsed,
+      councilModels: parsed.councilModels || DEFAULT_SETTINGS.councilModels,
+      chairmanModel: parsed.chairmanModel || DEFAULT_SETTINGS.chairmanModel,
+    };
+  } catch (err) {
+    console.warn('Failed to parse stored settings, using defaults', err);
+    return DEFAULT_SETTINGS;
+  }
+};
+
+export function useSettings() {
+  const [settings, setSettings] = useState(parseStoredSettings);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+  }, [settings]);
+
+  const updateSettings = useCallback((next) => {
+    setSettings((prev) => ({ ...prev, ...next }));
+  }, []);
+
+  const resetSettings = useCallback(() => {
+    setSettings(DEFAULT_SETTINGS);
+  }, []);
+
+  return { settings, updateSettings, resetSettings };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,6 +7,62 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  --app-bg: #f5f5f5;
+  --surface: #ffffff;
+  --surface-alt: #fafafa;
+  --surface-soft: #f9fafb;
+  --sidebar-bg: #f8f8f8;
+  --text-primary: #333333;
+  --text-secondary: #666666;
+  --text-muted: #999999;
+  --border-color: #e0e0e0;
+  --muted-border: #d0d0d0;
+  --accent: #4a90e2;
+  --accent-strong: #357abd;
+  --user-bubble-bg: #f0f7ff;
+  --user-bubble-border: #d0e7ff;
+  --stage-bg: #fafafa;
+  --stage3-bg: #f0fff0;
+  --stage3-border: #c8e6c8;
+  --aggregate-bg: #f0f7ff;
+  --aggregate-border: #d0e7ff;
+  --code-bg: #f5f5f5;
+  --blockquote-border: #dddddd;
+  --parsed-divider: #e0e0e0;
+  --spinner-track: #e0e0e0;
+  --input-disabled-bg: #f5f5f5;
+  --shadow-soft: 0 12px 36px rgba(0, 0, 0, 0.08);
+  --success: #2d8a2d;
+}
+
+.dark {
+  --app-bg: #0b1021;
+  --surface: #0f172a;
+  --surface-alt: #0b1220;
+  --surface-soft: #0f1627;
+  --sidebar-bg: #0d1424;
+  --text-primary: #e5e7eb;
+  --text-secondary: #cbd5e1;
+  --text-muted: #94a3b8;
+  --border-color: #1f2a3d;
+  --muted-border: #23334b;
+  --accent: #63a4ff;
+  --accent-strong: #7bb6ff;
+  --user-bubble-bg: #0f1f33;
+  --user-bubble-border: #1e3a56;
+  --stage-bg: #0f1627;
+  --stage3-bg: #0f241a;
+  --stage3-border: #1d3b2b;
+  --aggregate-bg: #0f1f33;
+  --aggregate-border: #1e3a56;
+  --code-bg: #111827;
+  --blockquote-border: #1e293b;
+  --parsed-divider: #1f2a3d;
+  --spinner-track: #1f2a3d;
+  --input-disabled-bg: #101828;
+  --shadow-soft: 0 12px 36px rgba(0, 0, 0, 0.35);
+  --success: #4ade80;
 }
 
 * {
@@ -19,7 +75,8 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  background: #f5f5f5;
+  background: var(--app-bg);
+  color: var(--text-primary);
 }
 
 #root {
@@ -70,7 +127,7 @@ body {
 }
 
 .markdown-content pre {
-  background: #f5f5f5;
+  background: var(--code-bg);
   padding: 12px;
   border-radius: 4px;
   overflow-x: auto;
@@ -78,7 +135,7 @@ body {
 }
 
 .markdown-content code {
-  background: #f5f5f5;
+  background: var(--code-bg);
   padding: 2px 6px;
   border-radius: 3px;
   font-family: monospace;
@@ -93,6 +150,6 @@ body {
 .markdown-content blockquote {
   margin: 0 0 12px 0;
   padding-left: 16px;
-  border-left: 4px solid #ddd;
-  color: #666;
+  border-left: 4px solid var(--blockquote-border);
+  color: var(--text-secondary);
 }

--- a/frontend/src/settings/defaults.js
+++ b/frontend/src/settings/defaults.js
@@ -1,0 +1,11 @@
+export const SETTINGS_STORAGE_KEY = 'llm-council-settings';
+
+export const DEFAULT_SETTINGS = {
+  councilModels: [
+    'openai/gpt-5.1',
+    'google/gemini-3-pro-preview',
+    'anthropic/claude-sonnet-4.5',
+    'x-ai/grok-4',
+  ],
+  chairmanModel: 'google/gemini-3-pro-preview',
+};

--- a/frontend/src/settings/defaults.js
+++ b/frontend/src/settings/defaults.js
@@ -1,11 +1,9 @@
-export const SETTINGS_STORAGE_KEY = 'llm-council-settings';
-
 export const DEFAULT_SETTINGS = {
-  councilModels: [
+  council_models: [
     'openai/gpt-5.1',
     'google/gemini-3-pro-preview',
     'anthropic/claude-sonnet-4.5',
     'x-ai/grok-4',
   ],
-  chairmanModel: 'google/gemini-3-pro-preview',
+  chairman_model: 'google/gemini-3-pro-preview',
 };


### PR DESCRIPTION
## Backend
- Added live/fallback model catalog (`/api/models`) that fetches OpenRouter models with caching and snapshot fallback (`data/availablemodels/openrouter.json`).
- Added settings persistence (`/api/settings`) storing council and chairman models in `data/settings.json`, validated against the catalog when available.
- Council execution now reads active settings (council + chairman) instead of hardcoded config defaults.

## Frontend
- Theme toggle persists (light/dark) with a bottom-left switch and CSS variables to adapt the UI.
- Settings panel (gear bottom-right) with:
  - Model dropdowns populated from the backend catalog, with manual entry fallback.
  - Save/reset flow that writes to backend settings; errors surfaced inline; reload option for the catalog source.
  - Chairman/council selections now mirror backend persistence (no more hardcoded warning).
- Tab title set to “LLM Council”.
- Expanded settings inputs to show full model names.

## Developer experience
- Broader `.gitignore` coverage (caches, logs, editor cruft, build artifacts).
- `.env.example` added for safe sharing of config keys.
