### PR TITLE
Add Render deployment option

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,8 @@
       "version": "20"
     }
   },
-  "postCreateCommand": "curl -LsSf https://astral.sh/uv/install.sh | sh && export PATH=\"$HOME/.local/bin:$PATH\" && make install",
-  "postStartCommand": "echo '\\n\\033[1;32m✓ LLM Council ready!\\033[0m\\n\\n  1. Run: make setup   (to add your OpenRouter API key)\\n  2. Run: make dev     (to start the app)\\n'",
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "postStartCommand": "bash .devcontainer/post-start.sh",
   "forwardPorts": [8001, 5173],
   "portsAttributes": {
     "8001": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+{
+  "name": "LLM Council",
+  "image": "mcr.microsoft.com/devcontainers/python:3.10",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
+  },
+  "postCreateCommand": "curl -LsSf https://astral.sh/uv/install.sh | sh && export PATH=\"$HOME/.local/bin:$PATH\" && make install",
+  "postStartCommand": "echo '\\n\\033[1;32m✓ LLM Council ready!\\033[0m\\n\\n  1. Run: make setup   (to add your OpenRouter API key)\\n  2. Run: make dev     (to start the app)\\n'",
+  "forwardPorts": [8001, 5173],
+  "portsAttributes": {
+    "8001": {
+      "label": "Backend API",
+      "onAutoForward": "silent"
+    },
+    "5173": {
+      "label": "Frontend",
+      "onAutoForward": "openBrowser"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": ".venv/bin/python"
+      }
+    }
+  },
+  "remoteEnv": {
+    "PATH": "${containerEnv:HOME}/.local/bin:${containerEnv:PATH}"
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Runs once when the Codespace is created
+
+set -e
+
+echo "Installing uv..."
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+
+echo "Installing dependencies..."
+make install
+
+echo "Creating .env from template..."
+cp .env.example .env
+
+echo "Setup complete!"

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Runs each time the Codespace starts
+
+echo ""
+echo "✓ LLM Council ready!"
+echo ""
+echo "  1. Edit .env and add your OpenRouter API key"
+echo "  2. Run: make dev"
+echo ""

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Get your API key at https://openrouter.ai/
+OPENROUTER_API_KEY=your-api-key-here

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,18 @@
+# Deployment
+
+## Render
+
+Deploy using Render's [Blueprint](https://render.com/docs/infrastructure-as-code) feature:
+
+1. Fork this repo
+2. Edit `render.yaml` and update the placeholder URLs:
+   - `CORS_ORIGINS` - Your frontend URL
+   - `VITE_API_URL` - Your backend URL
+3. In Render dashboard, click **New** > **Blueprint**
+4. Connect your forked repo
+5. Render will detect `render.yaml` and create the services
+6. Set `OPENROUTER_API_KEY` in the `llm-council-api` service environment variables
+
+Services created:
+- `llm-council-api` - Backend API
+- `llm-council` - Frontend static site

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+.PHONY: install install-backend install-frontend dev run backend frontend clean setup help
+
+# Default target
+help:
+	@echo "LLM Council - Available commands:"
+	@echo ""
+	@echo "  make setup      - Create .env file (interactive)"
+	@echo "  make install    - Install all dependencies"
+	@echo "  make dev        - Run both backend and frontend"
+	@echo "  make backend    - Run backend only (port 8001)"
+	@echo "  make frontend   - Run frontend only (port 5173)"
+	@echo "  make clean      - Remove generated files"
+	@echo ""
+
+# Setup .env file
+setup:
+	@if [ -f .env ]; then \
+		echo ".env file already exists"; \
+	else \
+		read -p "Enter your OpenRouter API key: " key; \
+		echo "OPENROUTER_API_KEY=$$key" > .env; \
+		echo ".env file created"; \
+	fi
+
+# Install all dependencies
+install: install-backend install-frontend
+	@echo ""
+	@echo "All dependencies installed!"
+	@echo "Run 'make setup' to configure your API key, then 'make dev' to start."
+
+install-backend:
+	@echo "Installing Python dependencies..."
+	uv sync
+
+install-frontend:
+	@echo "Installing frontend dependencies..."
+	cd frontend && npm install
+
+# Run both services
+dev run:
+	@./start.sh
+
+# Run backend only
+backend:
+	uv run python -m backend.main
+
+# Run frontend only
+frontend:
+	cd frontend && npm run dev
+
+# Clean generated files
+clean:
+	rm -rf frontend/node_modules
+	rm -rf frontend/dist
+	rm -rf .venv
+	rm -rf __pycache__
+	rm -rf backend/__pycache__
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	@echo "Cleaned!"

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,14 @@ help:
 	@echo "  make clean      - Remove generated files"
 	@echo ""
 
-# Setup .env file
+# Setup .env file from .env.example
 setup:
 	@if [ -f .env ]; then \
-		echo ".env file already exists"; \
+		echo ".env file already exists. Edit it to update your API key."; \
 	else \
-		read -p "Enter your OpenRouter API key: " key; \
-		echo "OPENROUTER_API_KEY=$$key" > .env; \
-		echo ".env file created"; \
+		cp .env.example .env; \
+		echo "Created .env from .env.example"; \
+		echo "Edit .env and add your OpenRouter API key (https://openrouter.ai/)"; \
 	fi
 
 # Install all dependencies

--- a/README.md
+++ b/README.md
@@ -14,28 +14,45 @@ In a bit more detail, here is what happens when you submit a query:
 
 This project was 99% vibe coded as a fun Saturday hack because I wanted to explore and evaluate a number of LLMs side by side in the process of [reading books together with LLMs](https://x.com/karpathy/status/1990577951671509438). It's nice and useful to see multiple responses side by side, and also the cross-opinions of all LLMs on each other's outputs. I'm not going to support it in any way, it's provided here as is for other people's inspiration and I don't intend to improve it. Code is ephemeral now and libraries are over, ask your LLM to change it in whatever way you like.
 
-## Setup
+## Quick Start with GitHub Codespaces
+
+The fastest way to try LLM Council - no local setup required:
+
+1. Click the button below to open in Codespaces:
+
+   [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/karpathy/llm-council)
+
+2. Once the codespace is ready, run:
+   ```bash
+   make setup    # Enter your OpenRouter API key
+   make dev      # Start the app
+   ```
+
+3. The frontend will open automatically in your browser.
+
+## Local Setup
 
 ### 1. Install Dependencies
 
-The project uses [uv](https://docs.astral.sh/uv/) for project management.
+The project uses [uv](https://docs.astral.sh/uv/) for Python and npm for the frontend.
 
-**Backend:**
 ```bash
-uv sync
+make install
 ```
 
-**Frontend:**
+Or manually:
 ```bash
-cd frontend
-npm install
-cd ..
+uv sync
+cd frontend && npm install && cd ..
 ```
 
 ### 2. Configure API Key
 
-Create a `.env` file in the project root:
+```bash
+make setup
+```
 
+Or manually create a `.env` file:
 ```bash
 OPENROUTER_API_KEY=sk-or-v1-...
 ```
@@ -59,12 +76,17 @@ CHAIRMAN_MODEL = "google/gemini-3-pro-preview"
 
 ## Running the Application
 
-**Option 1: Use the start script**
+**Option 1: Use Make (recommended)**
+```bash
+make dev
+```
+
+**Option 2: Use the start script**
 ```bash
 ./start.sh
 ```
 
-**Option 2: Run manually**
+**Option 3: Run manually**
 
 Terminal 1 (Backend):
 ```bash
@@ -78,6 +100,18 @@ npm run dev
 ```
 
 Then open http://localhost:5173 in your browser.
+
+## Available Make Commands
+
+```
+make help       # Show all commands
+make install    # Install all dependencies
+make setup      # Configure API key
+make dev        # Run both backend and frontend
+make backend    # Run backend only
+make frontend   # Run frontend only
+make clean      # Remove generated files
+```
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ In a bit more detail, here is what happens when you submit a query:
 
 This project was 99% vibe coded as a fun Saturday hack because I wanted to explore and evaluate a number of LLMs side by side in the process of [reading books together with LLMs](https://x.com/karpathy/status/1990577951671509438). It's nice and useful to see multiple responses side by side, and also the cross-opinions of all LLMs on each other's outputs. I'm not going to support it in any way, it's provided here as is for other people's inspiration and I don't intend to improve it. Code is ephemeral now and libraries are over, ask your LLM to change it in whatever way you like.
 
-## GitHub Codespaces
-
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/karpathy/llm-council)
-
-Edit `.env` with your [OpenRouter API key](https://openrouter.ai/), then run `make dev`.
-
 ## Setup
 
 ### 1. Install Dependencies
@@ -86,6 +80,14 @@ npm run dev
 ```
 
 Then open http://localhost:5173 in your browser.
+
+**Option 3: GitHub Codespaces**
+
+You can also just run the app in a Github codespace:
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/karpathy/llm-council)
+
+Edit `.env` with your [OpenRouter API key](https://openrouter.ai/), then run `make dev`.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -14,45 +14,34 @@ In a bit more detail, here is what happens when you submit a query:
 
 This project was 99% vibe coded as a fun Saturday hack because I wanted to explore and evaluate a number of LLMs side by side in the process of [reading books together with LLMs](https://x.com/karpathy/status/1990577951671509438). It's nice and useful to see multiple responses side by side, and also the cross-opinions of all LLMs on each other's outputs. I'm not going to support it in any way, it's provided here as is for other people's inspiration and I don't intend to improve it. Code is ephemeral now and libraries are over, ask your LLM to change it in whatever way you like.
 
-## Quick Start with GitHub Codespaces
+## GitHub Codespaces
 
-The fastest way to try LLM Council - no local setup required:
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/karpathy/llm-council)
 
-1. Click the button below to open in Codespaces:
+Edit `.env` with your [OpenRouter API key](https://openrouter.ai/), then run `make dev`.
 
-   [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/karpathy/llm-council)
-
-2. Once the codespace is ready, run:
-   ```bash
-   make setup    # Enter your OpenRouter API key
-   make dev      # Start the app
-   ```
-
-3. The frontend will open automatically in your browser.
-
-## Local Setup
+## Setup
 
 ### 1. Install Dependencies
 
-The project uses [uv](https://docs.astral.sh/uv/) for Python and npm for the frontend.
+The project uses [uv](https://docs.astral.sh/uv/) for project management.
 
-```bash
-make install
-```
-
-Or manually:
+**Backend:**
 ```bash
 uv sync
-cd frontend && npm install && cd ..
+```
+
+**Frontend:**
+```bash
+cd frontend
+npm install
+cd ..
 ```
 
 ### 2. Configure API Key
 
-```bash
-make setup
-```
+Create a `.env` file in the project root:
 
-Or manually create a `.env` file:
 ```bash
 OPENROUTER_API_KEY=sk-or-v1-...
 ```
@@ -76,17 +65,12 @@ CHAIRMAN_MODEL = "google/gemini-3-pro-preview"
 
 ## Running the Application
 
-**Option 1: Use Make (recommended)**
-```bash
-make dev
-```
-
-**Option 2: Use the start script**
+**Option 1: Use the start script**
 ```bash
 ./start.sh
 ```
 
-**Option 3: Run manually**
+**Option 2: Run manually**
 
 Terminal 1 (Backend):
 ```bash
@@ -100,18 +84,6 @@ npm run dev
 ```
 
 Then open http://localhost:5173 in your browser.
-
-## Available Make Commands
-
-```
-make help       # Show all commands
-make install    # Install all dependencies
-make setup      # Configure API key
-make dev        # Run both backend and frontend
-make backend    # Run backend only
-make frontend   # Run frontend only
-make clean      # Remove generated files
-```
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ CHAIRMAN_MODEL = "google/gemini-3-pro-preview"
 ./start.sh
 ```
 
+(or `make dev` if you prefer Make)
+
 **Option 2: Run manually**
 
 Terminal 1 (Backend):

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,23 +1,26 @@
 """FastAPI backend for LLM Council."""
 
+import os
+import uuid
+import json
+import asyncio
+from typing import List, Dict, Any
+
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
-from typing import List, Dict, Any
-import uuid
-import json
-import asyncio
 
 from . import storage
 from .council import run_full_council, generate_conversation_title, stage1_collect_responses, stage2_collect_rankings, stage3_synthesize_final, calculate_aggregate_rankings
 
 app = FastAPI(title="LLM Council API")
 
-# Enable CORS for local development
+# Enable CORS
+cors_origins = os.getenv("CORS_ORIGINS", "http://localhost:5173,http://localhost:3000").split(",")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://localhost:3000"],
+    allow_origins=cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2,7 +2,7 @@
  * API client for the LLM Council backend.
  */
 
-const API_BASE = 'http://localhost:8001';
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8001';
 
 export const api = {
   /**

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,22 @@
+services:
+  # Backend API
+  - type: web
+    name: llm-council-api
+    runtime: python
+    buildCommand: pip install uv && uv sync
+    startCommand: uv run python -m backend.main
+    envVars:
+      - key: OPENROUTER_API_KEY
+        sync: false  # User must set this manually in Render dashboard
+      - key: CORS_ORIGINS
+        value: https://llm-council.onrender.com
+
+  # Frontend static site
+  - type: web
+    name: llm-council
+    runtime: static
+    buildCommand: cd frontend && npm install && npm run build
+    staticPublishPath: frontend/dist
+    envVars:
+      - key: VITE_API_URL
+        value: https://llm-council-api.onrender.com

--- a/render.yaml
+++ b/render.yaml
@@ -7,9 +7,9 @@ services:
     startCommand: uv run python -m backend.main
     envVars:
       - key: OPENROUTER_API_KEY
-        sync: false  # User must set this manually in Render dashboard
+        sync: false  # Set in Render dashboard
       - key: CORS_ORIGINS
-        value: https://llm-council.onrender.com
+        value: https://llm-council-uc3k.onrender.com  # <-- Update to your frontend URL
 
   # Frontend static site
   - type: web
@@ -19,4 +19,4 @@ services:
     staticPublishPath: frontend/dist
     envVars:
       - key: VITE_API_URL
-        value: https://llm-council-api.onrender.com
+        value: https://llm-council-api.onrender.com  # <-- Update to your backend URL


### PR DESCRIPTION
This prob a bit silly but just in case users want to actually go extra step and get it deployed somewhere to share with friends and family or just as a way to go beyond localhost :) 

Adds support for deploying to Render using their Blueprint feature.

Changes:
- Add `render.yaml` for one-click Render deployment
- Add `DEPLOYMENT.md` with setup instructions
- Make API URL configurable via `VITE_API_URL` env var
- Make CORS origins configurable via `CORS_ORIGINS` env var