### PR TITLE
Add Render deployment option

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,18 @@
+# Deployment
+
+## Render
+
+Deploy using Render's [Blueprint](https://render.com/docs/infrastructure-as-code) feature:
+
+1. Fork this repo
+2. Edit `render.yaml` and update the placeholder URLs:
+   - `CORS_ORIGINS` - Your frontend URL
+   - `VITE_API_URL` - Your backend URL
+3. In Render dashboard, click **New** > **Blueprint**
+4. Connect your forked repo
+5. Render will detect `render.yaml` and create the services
+6. Set `OPENROUTER_API_KEY` in the `llm-council-api` service environment variables
+
+Services created:
+- `llm-council-api` - Backend API
+- `llm-council` - Frontend static site

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,23 +1,26 @@
 """FastAPI backend for LLM Council."""
 
+import os
+import uuid
+import json
+import asyncio
+from typing import List, Dict, Any
+
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
-from typing import List, Dict, Any
-import uuid
-import json
-import asyncio
 
 from . import storage
 from .council import run_full_council, generate_conversation_title, stage1_collect_responses, stage2_collect_rankings, stage3_synthesize_final, calculate_aggregate_rankings
 
 app = FastAPI(title="LLM Council API")
 
-# Enable CORS for local development
+# Enable CORS
+cors_origins = os.getenv("CORS_ORIGINS", "http://localhost:5173,http://localhost:3000").split(",")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://localhost:3000"],
+    allow_origins=cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -2,7 +2,7 @@
  * API client for the LLM Council backend.
  */
 
-const API_BASE = 'http://localhost:8001';
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8001';
 
 export const api = {
   /**

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,22 @@
+services:
+  # Backend API
+  - type: web
+    name: llm-council-api
+    runtime: python
+    buildCommand: pip install uv && uv sync
+    startCommand: uv run python -m backend.main
+    envVars:
+      - key: OPENROUTER_API_KEY
+        sync: false  # Set in Render dashboard
+      - key: CORS_ORIGINS
+        value: https://llm-council.onrender.com  # <-- Update to your frontend URL
+
+  # Frontend static site
+  - type: web
+    name: llm-council
+    runtime: static
+    buildCommand: cd frontend && npm install && npm run build
+    staticPublishPath: frontend/dist
+    envVars:
+      - key: VITE_API_URL
+        value: https://llm-council-api.onrender.com  # <-- Update to your backend URL


### PR DESCRIPTION
This prob a bit silly but just in case users want to actually go extra step and get it deployed somewhere to share with friends and family or just as a way to go beyond localhost :)

Adds support for deploying to Render using their Blueprint feature.

Changes:
- Add `render.yaml` for one-click Render deployment
- Add `DEPLOYMENT.md` with setup instructions
- Make API URL configurable via `VITE_API_URL` env var
- Make CORS origins configurable via `CORS_ORIGINS` env var