### PR TITLE
Fix model.split error when model is array

### DIFF
--- a/frontend/src/components/Stage1.jsx
+++ b/frontend/src/components/Stage1.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { getModelDisplayName } from '../utils';
 import './Stage1.css';
 
 export default function Stage1({ responses }) {
@@ -20,7 +21,7 @@ export default function Stage1({ responses }) {
             className={`tab ${activeTab === index ? 'active' : ''}`}
             onClick={() => setActiveTab(index)}
           >
-            {resp.model.split('/')[1] || resp.model}
+            {getModelDisplayName(resp.model)}
           </button>
         ))}
       </div>

--- a/frontend/src/components/Stage2.jsx
+++ b/frontend/src/components/Stage2.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { getModelDisplayName } from '../utils';
 import './Stage2.css';
 
 function deAnonymizeText(text, labelToModel) {
@@ -8,7 +9,7 @@ function deAnonymizeText(text, labelToModel) {
   let result = text;
   // Replace each "Response X" with the actual model name
   Object.entries(labelToModel).forEach(([label, model]) => {
-    const modelShortName = model.split('/')[1] || model;
+    const modelShortName = getModelDisplayName(model);
     result = result.replace(new RegExp(label, 'g'), `**${modelShortName}**`);
   });
   return result;
@@ -38,7 +39,7 @@ export default function Stage2({ rankings, labelToModel, aggregateRankings }) {
             className={`tab ${activeTab === index ? 'active' : ''}`}
             onClick={() => setActiveTab(index)}
           >
-            {rank.model.split('/')[1] || rank.model}
+            {getModelDisplayName(rank.model)}
           </button>
         ))}
       </div>
@@ -61,7 +62,7 @@ export default function Stage2({ rankings, labelToModel, aggregateRankings }) {
               {rankings[activeTab].parsed_ranking.map((label, i) => (
                 <li key={i}>
                   {labelToModel && labelToModel[label]
-                    ? labelToModel[label].split('/')[1] || labelToModel[label]
+                    ? getModelDisplayName(labelToModel[label])
                     : label}
                 </li>
               ))}
@@ -81,7 +82,7 @@ export default function Stage2({ rankings, labelToModel, aggregateRankings }) {
               <div key={index} className="aggregate-item">
                 <span className="rank-position">#{index + 1}</span>
                 <span className="rank-model">
-                  {agg.model.split('/')[1] || agg.model}
+                  {getModelDisplayName(agg.model)}
                 </span>
                 <span className="rank-score">
                   Avg: {agg.average_rank.toFixed(2)}

--- a/frontend/src/components/Stage3.jsx
+++ b/frontend/src/components/Stage3.jsx
@@ -1,4 +1,5 @@
 import ReactMarkdown from 'react-markdown';
+import { getModelDisplayName } from '../utils';
 import './Stage3.css';
 
 export default function Stage3({ finalResponse }) {
@@ -11,7 +12,7 @@ export default function Stage3({ finalResponse }) {
       <h3 className="stage-title">Stage 3: Final Council Answer</h3>
       <div className="final-response">
         <div className="chairman-label">
-          Chairman: {finalResponse.model.split('/')[1] || finalResponse.model}
+          Chairman: {getModelDisplayName(finalResponse.model)}
         </div>
         <div className="final-text markdown-content">
           <ReactMarkdown>{finalResponse.response}</ReactMarkdown>

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -1,0 +1,34 @@
+/**
+ * Utility functions for LLM Council frontend.
+ */
+
+/**
+ * Extract a display-friendly model name from a model identifier.
+ * Handles various edge cases: arrays, null/undefined, missing slash.
+ *
+ * @param {string|string[]|null|undefined} model - The model identifier
+ * @returns {string} The display name (e.g., "gpt-5.1" from "openai/gpt-5.1")
+ */
+export function getModelDisplayName(model) {
+  // Handle null/undefined
+  if (!model) {
+    return 'Unknown';
+  }
+
+  // Handle array (some APIs return model as array)
+  if (Array.isArray(model)) {
+    model = model[0];
+    if (!model) {
+      return 'Unknown';
+    }
+  }
+
+  // Handle non-string types
+  if (typeof model !== 'string') {
+    return String(model);
+  }
+
+  // Extract the part after the slash, or return the whole thing
+  const parts = model.split('/');
+  return parts.length > 1 ? parts[1] : model;
+}


### PR DESCRIPTION
## Summary

Fixes #117 - Frontend crashes when `model` is an array instead of a string.

## Problem

The frontend code calls `model.split('/')` but some API responses return `model` as an array (e.g., `["openai/gpt-4o"]`) instead of a string, causing:

```
TypeError: finalResponse.model.split is not a function
```

## Solution

Added `getModelDisplayName()` helper in `frontend/src/utils.js` that handles:
- Arrays (extracts first element)
- null/undefined (returns "Unknown")
- Non-string types (converts to string)
- Missing slash (returns whole string)

Updated Stage1, Stage2, and Stage3 components to use this helper.

## Validation

```javascript
// BEFORE (crashes):
finalResponse.model = ["openai/gpt-4o"]
finalResponse.model.split('/') → TypeError: split is not a function

// AFTER (works):
getModelDisplayName(["openai/gpt-4o"]) → "gpt-4o"
```

## Test plan

- [ ] Verify frontend doesn't crash when model is returned as array
- [ ] Verify normal string models still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)