### PR TITLE
Update Gemini model and chairman fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ Edit `backend/config.py` to customize the council:
 ```python
 COUNCIL_MODELS = [
     "openai/gpt-5.1",
-    "google/gemini-3-pro-preview",
+    "google/gemini-3.1-pro-preview",
     "anthropic/claude-sonnet-4.5",
     "x-ai/grok-4",
 ]
 
-CHAIRMAN_MODEL = "google/gemini-3-pro-preview"
+CHAIRMAN_MODEL = "google/gemini-3.1-pro-preview"
 ```
 
 ## Running the Application

--- a/backend/config.py
+++ b/backend/config.py
@@ -11,13 +11,13 @@ OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 # Council members - list of OpenRouter model identifiers
 COUNCIL_MODELS = [
     "openai/gpt-5.1",
-    "google/gemini-3-pro-preview",
+    "google/gemini-3.1-pro-preview",
     "anthropic/claude-sonnet-4.5",
     "x-ai/grok-4",
 ]
 
 # Chairman model - synthesizes final response
-CHAIRMAN_MODEL = "google/gemini-3-pro-preview"
+CHAIRMAN_MODEL = "google/gemini-3.1-pro-preview"
 
 # OpenRouter API endpoint
 OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"

--- a/backend/council.py
+++ b/backend/council.py
@@ -1,8 +1,13 @@
 """3-stage LLM Council orchestration."""
 
-from typing import List, Dict, Any, Tuple
+from typing import List, Dict, Any, Tuple, Optional
 from .openrouter import query_models_parallel, query_model
 from .config import COUNCIL_MODELS, CHAIRMAN_MODEL
+
+
+def is_successful_response(response: Optional[Dict[str, Any]]) -> bool:
+    """Return True when an OpenRouter response contains usable text."""
+    return bool(response and not response.get("error") and response.get("content"))
 
 
 async def stage1_collect_responses(user_query: str) -> List[Dict[str, Any]]:
@@ -23,7 +28,7 @@ async def stage1_collect_responses(user_query: str) -> List[Dict[str, Any]]:
     # Format results
     stage1_results = []
     for model, response in responses.items():
-        if response is not None:  # Only include successful responses
+        if is_successful_response(response):  # Only include successful responses
             stage1_results.append({
                 "model": model,
                 "response": response.get('content', '')
@@ -100,7 +105,7 @@ Now provide your evaluation and ranking:"""
     # Format results
     stage2_results = []
     for model, response in responses.items():
-        if response is not None:
+        if is_successful_response(response):
             full_text = response.get('content', '')
             parsed = parse_ranking_from_text(full_text)
             stage2_results.append({
@@ -158,20 +163,60 @@ Provide a clear, well-reasoned final answer that represents the council's collec
 
     messages = [{"role": "user", "content": chairman_prompt}]
 
-    # Query the chairman model
+    # Query the chairman model. If it fails, try other successful council
+    # members before returning an error to the user.
     response = await query_model(CHAIRMAN_MODEL, messages)
+    if not is_successful_response(response):
+        fallback_result = await _try_fallback_chairmen(
+            messages,
+            stage1_results,
+            exclude_model=CHAIRMAN_MODEL,
+        )
+        if fallback_result:
+            return fallback_result
 
-    if response is None:
-        # Fallback if chairman fails
+        error_detail = response.get("error") if response else "No response returned."
         return {
             "model": CHAIRMAN_MODEL,
-            "response": "Error: Unable to generate final synthesis."
+            "response": (
+                "Error: Unable to generate final synthesis.\n\n"
+                f"Chairman request failed for `{CHAIRMAN_MODEL}`: {error_detail}"
+            ),
+            "error": error_detail,
         }
 
     return {
         "model": CHAIRMAN_MODEL,
         "response": response.get('content', '')
     }
+
+
+async def _try_fallback_chairmen(
+    messages: List[Dict[str, str]],
+    stage1_results: List[Dict[str, Any]],
+    exclude_model: str,
+) -> Optional[Dict[str, Any]]:
+    """Try models that already succeeded in Stage 1 as synthesis fallbacks."""
+    fallback_models = [
+        result["model"]
+        for result in stage1_results
+        if result.get("model") and result["model"] != exclude_model
+    ]
+
+    for model in fallback_models:
+        response = await query_model(model, messages)
+        if is_successful_response(response):
+            return {
+                "model": model,
+                "response": (
+                    f"_Note: Chairman `{exclude_model}` failed, so `{model}` "
+                    "generated this final synthesis._\n\n"
+                    f"{response.get('content', '')}"
+                ),
+                "fallback_for": exclude_model,
+            }
+
+    return None
 
 
 def parse_ranking_from_text(ranking_text: str) -> List[str]:

--- a/backend/openrouter.py
+++ b/backend/openrouter.py
@@ -19,7 +19,8 @@ async def query_model(
         timeout: Request timeout in seconds
 
     Returns:
-        Response dict with 'content' and optional 'reasoning_details', or None if failed
+        Response dict with 'content' and optional 'reasoning_details', or an
+        'error' key if the request failed.
     """
     headers = {
         "Authorization": f"Bearer {OPENROUTER_API_KEY}",
@@ -48,9 +49,14 @@ async def query_model(
                 'reasoning_details': message.get('reasoning_details')
             }
 
+    except httpx.HTTPStatusError as e:
+        error = _format_http_error(e)
+        print(f"Error querying model {model}: {error}")
+        return {"content": None, "error": error}
     except Exception as e:
-        print(f"Error querying model {model}: {e}")
-        return None
+        error = f"{type(e).__name__}: {e}"
+        print(f"Error querying model {model}: {error}")
+        return {"content": None, "error": error}
 
 
 async def query_models_parallel(
@@ -65,7 +71,8 @@ async def query_models_parallel(
         messages: List of message dicts to send to each model
 
     Returns:
-        Dict mapping model identifier to response dict (or None if failed)
+        Dict mapping model identifier to response dict. Failed requests include
+        an 'error' key.
     """
     import asyncio
 
@@ -77,3 +84,25 @@ async def query_models_parallel(
 
     # Map models to their responses
     return {model: response for model, response in zip(models, responses)}
+
+
+def _format_http_error(error: httpx.HTTPStatusError) -> str:
+    """Extract the useful OpenRouter error payload from an HTTP failure."""
+    response = error.response
+    status = response.status_code
+
+    try:
+        data = response.json()
+    except ValueError:
+        body = response.text.strip()
+        if len(body) > 500:
+            body = body[:497] + "..."
+        return f"HTTP {status}: {body or response.reason_phrase}"
+
+    detail = data.get("error", data)
+    if isinstance(detail, dict):
+        message = detail.get("message") or detail.get("code") or str(detail)
+    else:
+        message = str(detail)
+
+    return f"HTTP {status}: {message}"


### PR DESCRIPTION
## Summary

- replace the retired `google/gemini-3-pro-preview` OpenRouter model ID with `google/gemini-3.1-pro-preview`
- return structured OpenRouter error details instead of collapsing failures to `None`
- if the configured chairman fails in Stage 3, try a council model that already succeeded in Stage 1 and mark the result with `fallback_for`

## Why

`google/gemini-3-pro-preview` currently returns `HTTP 404: No endpoints found for google/gemini-3-pro-preview` through OpenRouter. That makes Stage 3 fall back to the generic `Unable to generate final synthesis` message, which hides the actionable provider error.

## Validation

- `python -m py_compile backend/openrouter.py backend/council.py backend/config.py`
- replayed a saved Stage 3 request: `google/gemini-3.1-pro-preview` completed directly with no fallback
- confirmed upstream `backend/config.py` still references `google/gemini-3-pro-preview`
